### PR TITLE
Basic JDK 8 support

### DIFF
--- a/nb-configuration.xml
+++ b/nb-configuration.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project-shared-configuration>
+    <!--
+This file contains additional configuration written by modules in the NetBeans IDE.
+The configuration is intended to be shared among all the users of project and
+therefore it is assumed to be part of version control checkout.
+Without this configuration present, some functionality in the IDE may be limited or fail altogether.
+-->
+    <properties xmlns="http://www.netbeans.org/ns/maven-properties-data/1">
+        <!--
+Properties that influence various parts of the IDE, especially code formatting and the like. 
+You can copy and paste the single properties, into the pom.xml file and the IDE will pick them up.
+That way multiple projects can share the same settings (useful for formatting rules for example).
+Any value defined here will override the pom.xml file value but is only applicable to the current project.
+-->
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapAnnotationArgs>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapAnnotationArgs>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapAfterDotInChainedMethodCalls>false</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapAfterDotInChainedMethodCalls>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapFor>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapFor>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.generateParagraphTagOnBlankLines>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.generateParagraphTagOnBlankLines>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapChainedMethodCalls>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapChainedMethodCalls>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapMethodParams>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapMethodParams>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-line-wrap>none</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-line-wrap>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapArrayInit>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapArrayInit>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignJavadocExceptionDescriptions>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignJavadocExceptionDescriptions>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapAssignOps>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapAssignOps>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.tab-size>3</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.tab-size>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignJavadocReturnDescription>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignJavadocReturnDescription>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapDisjunctiveCatchTypes>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapDisjunctiveCatchTypes>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.indent-shift-width>3</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.indent-shift-width>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapExtendsImplementsList>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapExtendsImplementsList>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapTernaryOps>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapTernaryOps>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapThrowsKeyword>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapThrowsKeyword>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapTryResources>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapTryResources>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapMethodCallArgs>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapMethodCallArgs>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapWhileStatement>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapWhileStatement>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapExtendsImplementsKeyword>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapExtendsImplementsKeyword>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapEnumConstants>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapEnumConstants>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapForStatement>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapForStatement>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapIfStatement>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapIfStatement>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignJavadocParameterDescriptions>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignJavadocParameterDescriptions>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapThrowsList>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapThrowsList>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.importInnerClasses>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.importInnerClasses>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapAssert>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapAssert>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.continuationIndentSize>6</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.continuationIndentSize>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.importGroupsOrder>static *;java;javax;org;*;com</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.importGroupsOrder>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.separateStaticImports>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.separateStaticImports>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.spaces-per-tab>3</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.spaces-per-tab>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapBinaryOps>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapBinaryOps>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-limit-width>80</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-limit-width>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapDoWhileStatement>WRAP_IF_LONG</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapDoWhileStatement>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.blankLinesAfterClassHeader>0</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.blankLinesAfterClassHeader>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.spaceBeforeArrayInitLeftBrace>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.spaceBeforeArrayInitLeftBrace>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.expand-tabs>false</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.expand-tabs>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.text-line-wrap>none</org-netbeans-modules-editor-indent.CodeStyle.project.text-line-wrap>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>3</org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>3</org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>3</org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>80</org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>false</org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>
+        <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
+    </properties>
+</project-shared-configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,14 @@ Besides those there will be more special calendars like currently existing NYSE 
 				<role>Developer</role>
 			</roles>
 		</developer>
+		<developer>
+			<id>soujavamisterm</id>
+			<email>misterm@gmail.com</email>
+			<name>Michael Nascimento Santos</name>
+			<roles>
+				<role>Developer</role>
+			</roles>
+		</developer>
 	</developers>
 	<issueManagement>
 		<system>Sourceforge</system>
@@ -87,8 +95,8 @@ Besides those there will be more special calendars like currently existing NYSE 
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.1</version>
 					<configuration>
-						<source>1.5</source>
-						<target>1.5</target>
+						<source>1.8</source>
+						<target>1.8</target>
 					</configuration>
 				</plugin>
 				<plugin>
@@ -156,14 +164,17 @@ Besides those there will be more special calendars like currently existing NYSE 
 						</goals>
 					</execution>
 				</executions>
+                                <configuration>
+                                    <additionalparam>-Xdoclint:none</additionalparam>
+                                </configuration>
 			</plugin>
 		</plugins>
 	</build>
 	<dependencies>
 		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>2.4</version>
+			<groupId>org.threeten</groupId>
+			<artifactId>threeten-extra</artifactId>
+			<version>0.9</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/de/jollyday/CalendarHierarchy.java
+++ b/src/main/java/de/jollyday/CalendarHierarchy.java
@@ -29,7 +29,7 @@ import de.jollyday.util.ResourceUtil;
  */
 public class CalendarHierarchy {
 	private String id;
-	private Map<String, CalendarHierarchy> children = new HashMap<String, CalendarHierarchy>();
+	private Map<String, CalendarHierarchy> children = new HashMap<>();
 	private final CalendarHierarchy parent;
 	private ResourceUtil resourceUtil = new ResourceUtil();
 	private String fallbackDescription;

--- a/src/main/java/de/jollyday/Holiday.java
+++ b/src/main/java/de/jollyday/Holiday.java
@@ -15,9 +15,8 @@
  */
 package de.jollyday;
 
+import java.time.LocalDate;
 import java.util.Locale;
-
-import org.joda.time.LocalDate;
 
 import de.jollyday.util.ResourceUtil;
 

--- a/src/main/java/de/jollyday/HolidayManager.java
+++ b/src/main/java/de/jollyday/HolidayManager.java
@@ -15,15 +15,13 @@
  */
 package de.jollyday;
 
+import java.time.LocalDate;
 import java.util.Calendar;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import org.joda.time.LocalDate;
-import org.joda.time.ReadableInterval;
 
 import de.jollyday.caching.HolidayManagerValueHandler;
 import de.jollyday.configuration.ConfigurationProviderManager;
@@ -52,7 +50,7 @@ public abstract class HolidayManager {
 	/**
 	 * Cache for manager instances on a per country basis.
 	 */
-	private static final Cache<HolidayManager> MANAGER_CHACHE = new Cache<HolidayManager>();
+	private static final Cache<HolidayManager> MANAGER_CHACHE = new Cache<>();
 	/**
 	 * Manager for configuration providers. Delivers the jollyday configuration.
 	 */
@@ -60,7 +58,7 @@ public abstract class HolidayManager {
 	/**
 	 * the holiday cache
 	 */
-	private Cache<Set<Holiday>> holidayCache = new Cache<Set<Holiday>>();
+	private Cache<Set<Holiday>> holidayCache = new Cache<>();
 	/**
 	 * Utility for calendar operations
 	 */
@@ -273,7 +271,7 @@ public abstract class HolidayManager {
 	 * @return Set of supported calendar codes.
 	 */
 	public static Set<String> getSupportedCalendarCodes() {
-		Set<String> supportedCalendars = new HashSet<String>();
+		Set<String> supportedCalendars = new HashSet<>();
 		for (HolidayCalendar c : HolidayCalendar.values()) {
 			supportedCalendars.add(c.getId());
 		}
@@ -333,14 +331,16 @@ public abstract class HolidayManager {
 	/**
 	 * Returns the holidays for the requested interval and hierarchy structure.
 	 *
-	 * @param interval
-	 *            the interval in which the holidays lie.
+	 * @param startDateInclusive 
+	 *            the start date of the interval in which holidays lie, inclusive 
+	 * @param endDateInclusive 
+	 *            the end date of the interval in which holidays lie, inclusive
 	 * @param args
 	 *            a {@link java.lang.String} object.
 	 * @return list of holidays within the interval
 	 */
-	abstract public Set<Holiday> getHolidays(ReadableInterval interval,
-			String... args);
+	abstract public Set<Holiday> getHolidays(LocalDate startDateInclusive, 
+			LocalDate endDateInclusive, String... args);
 
 	/**
 	 * Returns the configured hierarchy structure for the specific manager. This

--- a/src/main/java/de/jollyday/configuration/impl/DefaultConfigurationProvider.java
+++ b/src/main/java/de/jollyday/configuration/impl/DefaultConfigurationProvider.java
@@ -51,6 +51,7 @@ public class DefaultConfigurationProvider implements ConfigurationProvider {
 	 * de.jollyday.configuration.ConfigurationProvider#addConfiguration(java
 	 * .util.Properties)
 	 */
+	@Override
 	public Properties getProperties() {
 		Properties properties = new Properties();
 		try {

--- a/src/main/java/de/jollyday/configuration/impl/URLConfigurationProvider.java
+++ b/src/main/java/de/jollyday/configuration/impl/URLConfigurationProvider.java
@@ -39,6 +39,7 @@ public class URLConfigurationProvider implements ConfigurationProvider {
 	 * Returns the properties by reading from the URLs provided by the system
 	 * property 'de.jollyday.config.urls'.
 	 */
+	@Override
 	public Properties getProperties() {
 		Properties properties = new Properties();
 		Properties systemProps = System.getProperties();

--- a/src/main/java/de/jollyday/datasource/impl/XmlFileDataSource.java
+++ b/src/main/java/de/jollyday/datasource/impl/XmlFileDataSource.java
@@ -31,6 +31,7 @@ public class XmlFileDataSource implements ConfigurationDataSource {
 	 */
 	private XMLUtil xmlUtil = new XMLUtil();
 
+	@Override
 	public Configuration getConfiguration(ManagerParameter parameter) {
 		try {
 			final InputStream inputStream = parameter.createResourceUrl().openStream();

--- a/src/main/java/de/jollyday/holidaytype/LocalizedHolidayType.java
+++ b/src/main/java/de/jollyday/holidaytype/LocalizedHolidayType.java
@@ -32,6 +32,7 @@ public enum LocalizedHolidayType implements HolidayType {
 		 * 
 		 * @see de.jollyday.HolidayType#isOfficialHoliday()
 		 */
+		@Override
 		public boolean isOfficialHoliday() {
 			return true;
 		}
@@ -42,6 +43,7 @@ public enum LocalizedHolidayType implements HolidayType {
 		 * 
 		 * @see de.jollyday.HolidayType#isOfficialHoliday()
 		 */
+		@Override
 		public boolean isOfficialHoliday() {
 			return false;
 		}

--- a/src/main/java/de/jollyday/impl/JapaneseHolidayManager.java
+++ b/src/main/java/de/jollyday/impl/JapaneseHolidayManager.java
@@ -15,10 +15,9 @@
  */
 package de.jollyday.impl;
 
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
-
-import org.joda.time.LocalDate;
 
 import de.jollyday.Holiday;
 import de.jollyday.holidaytype.LocalizedHolidayType;
@@ -47,7 +46,7 @@ public class JapaneseHolidayManager extends DefaultHolidayManager {
 	@Override
 	public Set<Holiday> getHolidays(int year, final String... args) {
 		Set<Holiday> holidays = super.getHolidays(year, args);
-		Set<Holiday> additionalHolidays = new HashSet<Holiday>();
+		Set<Holiday> additionalHolidays = new HashSet<>();
 		for (Holiday d : holidays) {
 			LocalDate twoDaysLater = d.getDate().plusDays(2);
 			if (calendarUtil.contains(holidays, twoDaysLater)) {

--- a/src/main/java/de/jollyday/parameter/BaseManagerParameter.java
+++ b/src/main/java/de/jollyday/parameter/BaseManagerParameter.java
@@ -14,6 +14,7 @@ public abstract class BaseManagerParameter implements ManagerParameter {
 		}
 	}
 	
+	@Override
 	public void mergeProperties(Properties properties) {
 		if(properties != null){
 			Properties mergedProperties = new Properties();
@@ -23,14 +24,17 @@ public abstract class BaseManagerParameter implements ManagerParameter {
 		}
 	}
 	
+	@Override
 	public String getProperty(String key){
 		return properties.getProperty(key);
 	}
 	
+	@Override
 	public void setProperty(String key, String value){
 		this.properties.setProperty(key, value);
 	}
 	
+	@Override
 	public String getManangerImplClassName() {
 		return getProperty(MANAGER_IMPL_CLASS_PREFIX);
 	}

--- a/src/main/java/de/jollyday/parameter/CalendarPartManagerParameter.java
+++ b/src/main/java/de/jollyday/parameter/CalendarPartManagerParameter.java
@@ -28,14 +28,17 @@ public class CalendarPartManagerParameter extends BaseManagerParameter {
 		this.calendarPart = calendarPart;
 	}
 
+	@Override
 	public String createCacheKey() {
 		return calendarPart;
 	}
 
+	@Override
 	public String getDisplayName() {
 		return calendarPart;
 	}
 
+	@Override
 	public URL createResourceUrl() {
 		String configurationFileName = getConfigurationFileName(calendarPart);
 		return resourceUtil.getResource(configurationFileName);

--- a/src/main/java/de/jollyday/parameter/UrlManagerParameter.java
+++ b/src/main/java/de/jollyday/parameter/UrlManagerParameter.java
@@ -12,14 +12,17 @@ public class UrlManagerParameter extends BaseManagerParameter {
 		this.calendarFileUrl = calendarFileUrl;
 	}
 
+	@Override
 	public String createCacheKey() {
 		return calendarFileUrl.toString();
 	}
 
+	@Override
 	public String getDisplayName() {
 		return calendarFileUrl.toString();
 	}
 
+	@Override
 	public URL createResourceUrl() {
 		return calendarFileUrl;
 	}

--- a/src/main/java/de/jollyday/parser/AbstractHolidayParser.java
+++ b/src/main/java/de/jollyday/parser/AbstractHolidayParser.java
@@ -15,7 +15,8 @@
  */
 package de.jollyday.parser;
 
-import org.joda.time.LocalDate;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 
 import de.jollyday.config.ChronologyType;
 import de.jollyday.config.Holiday;
@@ -154,7 +155,7 @@ public abstract class AbstractHolidayParser implements HolidayParser {
 	 * @return
 	 */
 	private LocalDate moveDate(MovingCondition mc, LocalDate fixed) {
-		int weekday = xmlUtil.getWeekday(mc.getWeekday());
+		DayOfWeek weekday = xmlUtil.getWeekday(mc.getWeekday());
 		int direction = (mc.getWith() == With.NEXT ? 1 : -1);
 		while (fixed.getDayOfWeek() != weekday) {
 			fixed = fixed.plusDays(direction);

--- a/src/main/java/de/jollyday/parser/impl/ChristianHolidayParser.java
+++ b/src/main/java/de/jollyday/parser/impl/ChristianHolidayParser.java
@@ -15,12 +15,12 @@
  */
 package de.jollyday.parser.impl;
 
+import java.time.LocalDate;
+import java.util.Set;
+
 import de.jollyday.Holiday;
 import de.jollyday.config.ChristianHoliday;
 import de.jollyday.config.Holidays;
-import org.joda.time.LocalDate;
-
-import java.util.Set;
 
 /**
  * This parser creates christian holidays for the given year relative to easter
@@ -36,6 +36,7 @@ public class ChristianHolidayParser extends RelativeToEasterSundayParser {
 	 *
 	 * Parses all christian holidays relative to eastern.
 	 */
+	@Override
 	public void parse(int year, Set<Holiday> holidays, final Holidays config) {
 		for (ChristianHoliday ch : config.getChristianHoliday()) {
 			if (!isValid(ch, year)) {
@@ -97,7 +98,7 @@ public class ChristianHolidayParser extends RelativeToEasterSundayParser {
 			}
             easterSunday = moveDate(ch, easterSunday);
 			String propertiesKey = "christian." + ch.getType().name();
-			addChrstianHoliday(easterSunday, propertiesKey, ch.getLocalizedType(), holidays);
+			addChristianHoliday(easterSunday, propertiesKey, ch.getLocalizedType(), holidays);
 		}
 	}
 

--- a/src/main/java/de/jollyday/parser/impl/EthiopianOrthodoxHolidayParser.java
+++ b/src/main/java/de/jollyday/parser/impl/EthiopianOrthodoxHolidayParser.java
@@ -15,9 +15,8 @@
  */
 package de.jollyday.parser.impl;
 
+import java.time.LocalDate;
 import java.util.Set;
-
-import org.joda.time.LocalDate;
 
 import de.jollyday.Holiday;
 import de.jollyday.HolidayType;
@@ -45,6 +44,7 @@ public class EthiopianOrthodoxHolidayParser extends AbstractHolidayParser {
 	 * de.jollyday.config.Holidays)
 	 */
 	/** {@inheritDoc} */
+	@Override
 	public void parse(int year, Set<Holiday> holidays, Holidays config) {
 		for (EthiopianOrthodoxHoliday h : config.getEthiopianOrthodoxHoliday()) {
 			if (!isValid(h, year)) {

--- a/src/main/java/de/jollyday/parser/impl/FixedParser.java
+++ b/src/main/java/de/jollyday/parser/impl/FixedParser.java
@@ -15,9 +15,8 @@
  */
 package de.jollyday.parser.impl;
 
+import java.time.LocalDate;
 import java.util.Set;
-
-import org.joda.time.LocalDate;
 
 import de.jollyday.Holiday;
 import de.jollyday.HolidayType;
@@ -40,6 +39,7 @@ public class FixedParser extends AbstractHolidayParser {
 	 * de.jollyday.config.Holidays)
 	 */
 	/** {@inheritDoc} */
+	@Override
 	public void parse(int year, Set<Holiday> holidays, final Holidays config) {
 		for (Fixed f : config.getFixed()) {
 			if (!isValid(f, year)) {

--- a/src/main/java/de/jollyday/parser/impl/FixedWeekdayBetweenFixedParser.java
+++ b/src/main/java/de/jollyday/parser/impl/FixedWeekdayBetweenFixedParser.java
@@ -15,9 +15,8 @@
  */
 package de.jollyday.parser.impl;
 
+import java.time.LocalDate;
 import java.util.Set;
-
-import org.joda.time.LocalDate;
 
 import de.jollyday.Holiday;
 import de.jollyday.HolidayType;
@@ -39,6 +38,7 @@ public class FixedWeekdayBetweenFixedParser extends AbstractHolidayParser {
 	 * Parses the provided configuration and creates holidays for the provided
 	 * year.
 	 */
+	@Override
 	public void parse(int year, Set<Holiday> holidays, final Holidays config) {
 		for (FixedWeekdayBetweenFixed fwm : config.getFixedWeekdayBetweenFixed()) {
 			if (!isValid(fwm, year)) {

--- a/src/main/java/de/jollyday/parser/impl/FixedWeekdayInMonthParser.java
+++ b/src/main/java/de/jollyday/parser/impl/FixedWeekdayInMonthParser.java
@@ -15,9 +15,11 @@
  */
 package de.jollyday.parser.impl;
 
-import java.util.Set;
+import static java.time.temporal.TemporalAdjusters.lastDayOfMonth;
 
-import org.joda.time.LocalDate;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.Set;
 
 import de.jollyday.Holiday;
 import de.jollyday.HolidayType;
@@ -41,6 +43,7 @@ public class FixedWeekdayInMonthParser extends AbstractHolidayParser {
 	 * de.jollyday.config.Holidays)
 	 */
 	/** {@inheritDoc} */
+	@Override
 	public void parse(int year, Set<Holiday> holidays, final Holidays config) {
 		for (FixedWeekdayInMonth fwm : config.getFixedWeekday()) {
 			if (!isValid(fwm, year)) {
@@ -65,7 +68,7 @@ public class FixedWeekdayInMonthParser extends AbstractHolidayParser {
 		LocalDate date = calendarUtil.create(year, xmlUtil.getMonth(fwm.getMonth()), 1);
 		int direction = 1;
 		if (Which.LAST.equals(fwm.getWhich())) {
-			date = date.withDayOfMonth(date.dayOfMonth().getMaximumValue());
+			date = date.with(lastDayOfMonth());
 			direction = -1;
 		}
 		date = moveToNextRequestedWeekdayByDirection(fwm, date, direction);
@@ -87,7 +90,7 @@ public class FixedWeekdayInMonthParser extends AbstractHolidayParser {
 	}
 
 	private LocalDate moveToNextRequestedWeekdayByDirection(FixedWeekdayInMonth fwm, LocalDate date, int direction) {
-		int weekDay = xmlUtil.getWeekday(fwm.getWeekday());
+		DayOfWeek weekDay = xmlUtil.getWeekday(fwm.getWeekday());
 		while (date.getDayOfWeek() != weekDay) {
 			date = date.plusDays(direction);
 		}

--- a/src/main/java/de/jollyday/parser/impl/FixedWeekdayRelativeToFixedParser.java
+++ b/src/main/java/de/jollyday/parser/impl/FixedWeekdayRelativeToFixedParser.java
@@ -15,9 +15,8 @@
  */
 package de.jollyday.parser.impl;
 
+import java.time.LocalDate;
 import java.util.Set;
-
-import org.joda.time.LocalDate;
 
 import de.jollyday.Holiday;
 import de.jollyday.HolidayType;
@@ -38,6 +37,7 @@ public class FixedWeekdayRelativeToFixedParser extends AbstractHolidayParser {
 	 * Parses the provided configuration and creates holidays for the provided
 	 * year.
 	 */
+	@Override
 	public void parse(int year, Set<Holiday> holidays, final Holidays config) {
 		for (FixedWeekdayRelativeToFixed f : config.getFixedWeekdayRelativeToFixed()) {
 			if (!isValid(f, year)) {

--- a/src/main/java/de/jollyday/parser/impl/HinduHolidayParser.java
+++ b/src/main/java/de/jollyday/parser/impl/HinduHolidayParser.java
@@ -31,6 +31,7 @@ import de.jollyday.parser.AbstractHolidayParser;
 public class HinduHolidayParser extends AbstractHolidayParser {
 
 	/** {@inheritDoc} */
+	@Override
 	public void parse(int year, Set<Holiday> holidays, final Holidays config) {
 		for (HinduHoliday hh : config.getHinduHoliday()) {
 			if (!isValid(hh, year))

--- a/src/main/java/de/jollyday/parser/impl/IslamicHolidayParser.java
+++ b/src/main/java/de/jollyday/parser/impl/IslamicHolidayParser.java
@@ -15,10 +15,8 @@
  */
 package de.jollyday.parser.impl;
 
+import java.time.LocalDate;
 import java.util.Set;
-
-import org.joda.time.DateTimeConstants;
-import org.joda.time.LocalDate;
 
 import de.jollyday.Holiday;
 import de.jollyday.HolidayType;
@@ -46,6 +44,7 @@ public class IslamicHolidayParser extends AbstractHolidayParser {
 	 * de.jollyday.config.Holidays)
 	 */
 	/** {@inheritDoc} */
+	@Override
 	public void parse(int year, Set<Holiday> holidays, final Holidays config) {
 		for (IslamicHoliday i : config.getIslamicHoliday()) {
 			if (!isValid(i, year)) {
@@ -54,31 +53,31 @@ public class IslamicHolidayParser extends AbstractHolidayParser {
 			Set<LocalDate> islamicHolidays = null;
 			switch (i.getType()) {
 			case NEWYEAR:
-				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, DateTimeConstants.JANUARY, 1);
+				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, 1, 1);
 				break;
 			case ASCHURA:
-				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, DateTimeConstants.JANUARY, 10);
+				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, 1, 10);
 				break;
 			case ID_AL_FITR:
-				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, DateTimeConstants.OCTOBER, 1);
+				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, 10, 1);
 				break;
 			case ID_UL_ADHA:
-				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, DateTimeConstants.DECEMBER, 10);
+				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, 12, 10);
 				break;
 			case LAILAT_AL_BARAT:
-				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, DateTimeConstants.AUGUST, 15);
+				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, 8, 15);
 				break;
 			case LAILAT_AL_MIRAJ:
-				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, DateTimeConstants.JULY, 27);
+				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, 7, 27);
 				break;
 			case LAILAT_AL_QADR:
-				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, DateTimeConstants.SEPTEMBER, 27);
+				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, 9, 27);
 				break;
 			case MAWLID_AN_NABI:
-				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, DateTimeConstants.MARCH, 12);
+				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, 3, 12);
 				break;
 			case RAMADAN:
-				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, DateTimeConstants.SEPTEMBER, 1);
+				islamicHolidays = calendarUtil.getIslamicHolidaysInGregorianYear(year, 9, 1);
 				break;
 			default:
 				throw new IllegalArgumentException("Unknown islamic holiday " + i.getType());

--- a/src/main/java/de/jollyday/parser/impl/RelativeToEasterSundayParser.java
+++ b/src/main/java/de/jollyday/parser/impl/RelativeToEasterSundayParser.java
@@ -15,9 +15,8 @@
  */
 package de.jollyday.parser.impl;
 
+import java.time.LocalDate;
 import java.util.Set;
-
-import org.joda.time.LocalDate;
 
 import de.jollyday.Holiday;
 import de.jollyday.config.HolidayType;
@@ -43,6 +42,7 @@ public class RelativeToEasterSundayParser extends AbstractHolidayParser {
 	 * 
 	 * Parses relative to easter sunday holidays.
 	 */
+	@Override
 	public void parse(int year, Set<Holiday> holidays, Holidays config) {
 		for (RelativeToEasterSunday ch : config.getRelativeToEasterSunday()) {
 			if (!isValid(ch, year)) {
@@ -50,7 +50,7 @@ public class RelativeToEasterSundayParser extends AbstractHolidayParser {
 			}
 			LocalDate easterSunday = getEasterSunday(year, ch.getChronology()).plusDays(ch.getDays());
 			String propertiesKey = PREFIX_PROPERTY_CHRISTIAN + ch.getDescriptionPropertiesKey();
-			addChrstianHoliday(easterSunday, propertiesKey, ch.getLocalizedType(), holidays);
+			addChristianHoliday(easterSunday, propertiesKey, ch.getLocalizedType(), holidays);
 		}
 	}
 
@@ -66,11 +66,10 @@ public class RelativeToEasterSundayParser extends AbstractHolidayParser {
 	 * @param holidays
 	 *            a {@link java.util.Set} object.
 	 */
-	protected void addChrstianHoliday(LocalDate day, String propertiesKey, HolidayType holidayType,
+	protected void addChristianHoliday(LocalDate day, String propertiesKey, HolidayType holidayType,
 			Set<Holiday> holidays) {
-		LocalDate convertedDate = calendarUtil.convertToISODate(day);
 		de.jollyday.HolidayType type = xmlUtil.getType(holidayType);
-		Holiday h = new Holiday(convertedDate, propertiesKey, type);
+		Holiday h = new Holiday(day, propertiesKey, type);
 		holidays.add(h);
 	}
 

--- a/src/main/java/de/jollyday/parser/impl/RelativeToFixedParser.java
+++ b/src/main/java/de/jollyday/parser/impl/RelativeToFixedParser.java
@@ -15,9 +15,9 @@
  */
 package de.jollyday.parser.impl;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.util.Set;
-
-import org.joda.time.LocalDate;
 
 import de.jollyday.Holiday;
 import de.jollyday.HolidayType;
@@ -41,6 +41,7 @@ public class RelativeToFixedParser extends AbstractHolidayParser {
 	 * de.jollyday.config.Holidays)
 	 */
 	/** {@inheritDoc} */
+	@Override
 	public void parse(int year, Set<Holiday> holidays, final Holidays config) {
 		for (RelativeToFixed rf : config.getRelativeToFixed()) {
 			if (!isValid(rf, year)) {
@@ -49,7 +50,7 @@ public class RelativeToFixedParser extends AbstractHolidayParser {
 			LocalDate fixed = calendarUtil.create(year, rf.getDate());
 			if (rf.getWeekday() != null) {
 				// if weekday is set -> move to weekday
-				int day = xmlUtil.getWeekday(rf.getWeekday());
+				DayOfWeek day = xmlUtil.getWeekday(rf.getWeekday());
 				int direction = (rf.getWhen() == When.BEFORE ? -1 : 1);
 				while (fixed.getDayOfWeek() != day){
 					fixed = fixed.plusDays(direction);

--- a/src/main/java/de/jollyday/parser/impl/RelativeToWeekdayInMonthParser.java
+++ b/src/main/java/de/jollyday/parser/impl/RelativeToWeekdayInMonthParser.java
@@ -15,9 +15,8 @@
  */
 package de.jollyday.parser.impl;
 
+import java.time.LocalDate;
 import java.util.Set;
-
-import org.joda.time.LocalDate;
 
 import de.jollyday.Holiday;
 import de.jollyday.HolidayType;

--- a/src/main/java/de/jollyday/util/Cache.java
+++ b/src/main/java/de/jollyday/util/Cache.java
@@ -29,7 +29,7 @@ public class Cache<VALUE> {
 	/**
 	 * Map for caching
 	 */
-	private Map<String, VALUE> cachingMap = new HashMap<String, VALUE>();
+	private Map<String, VALUE> cachingMap = new HashMap<>();
 	/**
 	 * Lock for accessing the map
 	 */

--- a/src/main/java/de/jollyday/util/ResourceUtil.java
+++ b/src/main/java/de/jollyday/util/ResourceUtil.java
@@ -58,11 +58,11 @@ public class ResourceUtil {
 	/**
 	 * Cache for the holiday descriptions resource bundles.
 	 */
-	private static final Map<Locale, ResourceBundle> HOLIDAY_DESCRIPTION_CACHE = new HashMap<Locale, ResourceBundle>();
+	private static final Map<Locale, ResourceBundle> HOLIDAY_DESCRIPTION_CACHE = new HashMap<>();
 	/**
 	 * Cache for the country descriptions resource bundles.
 	 */
-	private final static Map<Locale, ResourceBundle> COUNTRY_DESCRIPTIONS_CACHE = new HashMap<Locale, ResourceBundle>();
+	private final static Map<Locale, ResourceBundle> COUNTRY_DESCRIPTIONS_CACHE = new HashMap<>();
 	/**
 	 * Util class to provide the correct classloader.
 	 */
@@ -127,7 +127,7 @@ public class ResourceUtil {
 	 * @return 2-digit ISO codes.
 	 */
 	public Set<String> getISOCodes() {
-		Set<String> codes = new HashSet<String>();
+		Set<String> codes = new HashSet<>();
 		ResourceBundle countryDescriptions = getCountryDescriptions(Locale.getDefault());
 		for (String property : Collections.list(countryDescriptions.getKeys())) {
 			String[] split = property.split("\\.");

--- a/src/main/java/de/jollyday/util/XMLUtil.java
+++ b/src/main/java/de/jollyday/util/XMLUtil.java
@@ -20,14 +20,13 @@ package de.jollyday.util;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.DayOfWeek;
 import java.util.logging.Logger;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
-
-import org.joda.time.DateTimeConstants;
 
 import de.jollyday.HolidayType;
 import de.jollyday.config.Configuration;
@@ -89,28 +88,11 @@ public class XMLUtil {
 	 * 
 	 * @param weekday
 	 *            a {@link de.jollyday.config.Weekday} object.
-	 * @return DateTimeConstants value.
+	 * @return a DayOfWeek instance.
 	 */
-	public final int getWeekday(Weekday weekday) {
-		switch (weekday) {
-		case MONDAY:
-			return DateTimeConstants.MONDAY;
-		case TUESDAY:
-			return DateTimeConstants.TUESDAY;
-		case WEDNESDAY:
-			return DateTimeConstants.WEDNESDAY;
-		case THURSDAY:
-			return DateTimeConstants.THURSDAY;
-		case FRIDAY:
-			return DateTimeConstants.FRIDAY;
-		case SATURDAY:
-			return DateTimeConstants.SATURDAY;
-		case SUNDAY:
-			return DateTimeConstants.SUNDAY;
-		default:
-			throw new IllegalArgumentException("Unknown weekday " + weekday);
+	public final DayOfWeek getWeekday(Weekday weekday) {
+		return DayOfWeek.valueOf(weekday.value());
 		}
-	}
 
 	/**
 	 * Returns the <code>DateTimeConstants</code> value for the given month.
@@ -122,29 +104,29 @@ public class XMLUtil {
 	public int getMonth(Month month) {
 		switch (month) {
 		case JANUARY:
-			return DateTimeConstants.JANUARY;
+			return 1;
 		case FEBRUARY:
-			return DateTimeConstants.FEBRUARY;
+			return 2;
 		case MARCH:
-			return DateTimeConstants.MARCH;
+			return 3;
 		case APRIL:
-			return DateTimeConstants.APRIL;
+			return 4;
 		case MAY:
-			return DateTimeConstants.MAY;
+			return 5;
 		case JUNE:
-			return DateTimeConstants.JUNE;
+			return 6;
 		case JULY:
-			return DateTimeConstants.JULY;
+			return 7;
 		case AUGUST:
-			return DateTimeConstants.AUGUST;
+			return 8;
 		case SEPTEMBER:
-			return DateTimeConstants.SEPTEMBER;
+			return 9;
 		case OCTOBER:
-			return DateTimeConstants.OCTOBER;
+			return 10;
 		case NOVEMBER:
-			return DateTimeConstants.NOVEMBER;
+			return 11;
 		case DECEMBER:
-			return DateTimeConstants.DECEMBER;
+			return 12;
 		default:
 			throw new IllegalArgumentException("Unknown month " + month);
 		}

--- a/src/test/java/de/jollyday/configuration/TestProvider.java
+++ b/src/test/java/de/jollyday/configuration/TestProvider.java
@@ -29,6 +29,7 @@ public class TestProvider implements ConfigurationProvider {
 		properties.setProperty("key", "value");
 	}
 	
+	@Override
 	public Properties getProperties() {
 		return properties;
 	}

--- a/src/test/java/de/jollyday/configuration/impl/DefaultConfigurationProviderContentTest.java
+++ b/src/test/java/de/jollyday/configuration/impl/DefaultConfigurationProviderContentTest.java
@@ -14,7 +14,7 @@ import de.jollyday.configuration.impl.DefaultConfigurationProvider;
 
 public class DefaultConfigurationProviderContentTest {
 
-	private static final Set<String> KEYS_DEFAULT_CONFIG = new HashSet<String>(Arrays.asList("manager.impl",
+	private static final Set<String> KEYS_DEFAULT_CONFIG = new HashSet<>(Arrays.asList("manager.impl",
 			"manager.impl.jp","configuration.datasource.impl","parser.impl.de.jollyday.config.Fixed",
 			"parser.impl.de.jollyday.config.FixedWeekdayInMonth", "parser.impl.de.jollyday.config.IslamicHoliday",
 			"parser.impl.de.jollyday.config.ChristianHoliday", "parser.impl.de.jollyday.config.RelativeToFixed",

--- a/src/test/java/de/jollyday/tests/HolidayDETest.java
+++ b/src/test/java/de/jollyday/tests/HolidayDETest.java
@@ -15,6 +15,7 @@
  */
 package de.jollyday.tests;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -22,8 +23,6 @@ import java.util.Set;
 
 import junit.framework.Assert;
 
-import org.joda.time.Interval;
-import org.joda.time.LocalDate;
 import org.junit.Test;
 
 import de.jollyday.Holiday;
@@ -48,9 +47,8 @@ public class HolidayDETest extends AbstractCountryTestBase {
 	public void testManagerDEinterval() {
 		try {
 			HolidayManager instance = HolidayManager.getInstance(HolidayCalendar.GERMANY);
-			Interval interval = new Interval(calendarUtil.create(2010, 10, 1).toDateTimeAtStartOfDay(), calendarUtil
-					.create(2011, 1, 31).toDateTimeAtStartOfDay());
-			Set<Holiday> holidays = instance.getHolidays(interval);
+			Set<Holiday> holidays = instance.getHolidays(calendarUtil.create(2010, 10, 1), calendarUtil
+					.create(2011, 1, 31));
 			List<LocalDate> expected = Arrays.asList(calendarUtil.create(2010, 12, 25),
 					calendarUtil.create(2010, 12, 26), calendarUtil.create(2010, 10, 3),
 					calendarUtil.create(2011, 1, 1));

--- a/src/test/java/de/jollyday/tests/HolidayDescriptionTest.java
+++ b/src/test/java/de/jollyday/tests/HolidayDescriptionTest.java
@@ -40,6 +40,7 @@ public class HolidayDescriptionTest {
 		Assert.assertTrue(folder.isDirectory());
 		File[] descriptions = folder.listFiles(new FilenameFilter() {
 
+			@Override
 			public boolean accept(File dir, String name) {
 				return name.startsWith("holiday_descriptions") && name.endsWith(".properties");
 			}
@@ -47,8 +48,8 @@ public class HolidayDescriptionTest {
 		Assert.assertNotNull(descriptions);
 		Assert.assertTrue(descriptions.length > 0);
 
-		Set<String> propertiesNames = new HashSet<String>();
-		Map<String, Properties> descriptionProperties = new HashMap<String, Properties>();
+		Set<String> propertiesNames = new HashSet<>();
+		Map<String, Properties> descriptionProperties = new HashMap<>();
 
 		for (File descriptionFile : descriptions) {
 			Properties props = new Properties();
@@ -57,11 +58,11 @@ public class HolidayDescriptionTest {
 			descriptionProperties.put(descriptionFile.getName(), props);
 		}
 
-		Map<String, Set<String>> missingProperties = new HashMap<String, Set<String>>();
+		Map<String, Set<String>> missingProperties = new HashMap<>();
 
 		for (Map.Entry<String, Properties> entry : descriptionProperties.entrySet()) {
 			if (!entry.getValue().stringPropertyNames().containsAll(propertiesNames)) {
-				Set<String> remainingProps = new HashSet<String>(propertiesNames);
+				Set<String> remainingProps = new HashSet<>(propertiesNames);
 				remainingProps.removeAll(entry.getValue().stringPropertyNames());
 				missingProperties.put(entry.getKey(), remainingProps);
 			}

--- a/src/test/java/de/jollyday/tests/HolidayTest.java
+++ b/src/test/java/de/jollyday/tests/HolidayTest.java
@@ -102,9 +102,9 @@ public class HolidayTest {
 		test_days_l11.add(LocalDate.of(2010, NOVEMBER,
 				17));
 		test_days_l11.add(LocalDate.of(2010, DECEMBER,
-				8));
+				7));
 		test_days_l11.add(LocalDate.of(2010, DECEMBER,
-				17));
+				16));
 	}
 
 	private Locale defaultLocale;

--- a/src/test/java/de/jollyday/tests/HolidayTest.java
+++ b/src/test/java/de/jollyday/tests/HolidayTest.java
@@ -15,8 +15,17 @@
  */
 package de.jollyday.tests;
 
+import static java.time.Month.APRIL;
+import static java.time.Month.AUGUST;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JULY;
+import static java.time.Month.NOVEMBER;
+import static java.time.Month.SEPTEMBER;
 import static org.junit.Assert.assertFalse;
 
+import java.time.LocalDate;
 import java.util.Calendar;
 import java.util.HashSet;
 import java.util.Locale;
@@ -28,12 +37,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import junit.framework.Assert;
 
-import org.joda.time.DateTimeConstants;
-import org.joda.time.LocalDate;
-import org.joda.time.chrono.ISOChronology;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,51 +61,49 @@ public class HolidayTest {
 	private final static Logger LOG = Logger.getLogger(HolidayTest.class
 			.getName());
 
-	private static final Set<LocalDate> test_days = new HashSet<LocalDate>();
-	private static final Set<LocalDate> test_days_l1 = new HashSet<LocalDate>();
-	private static final Set<LocalDate> test_days_l2 = new HashSet<LocalDate>();
-	private static final Set<LocalDate> test_days_l11 = new HashSet<LocalDate>();
+	private static final Set<LocalDate> test_days = new HashSet<>();
+	private static final Set<LocalDate> test_days_l1 = new HashSet<>();
+	private static final Set<LocalDate> test_days_l2 = new HashSet<>();
+	private static final Set<LocalDate> test_days_l11 = new HashSet<>();
 
 	private static CalendarUtil calendarUtil = new CalendarUtil();
 
 	static {
 		test_days
-				.add(calendarUtil.create(2010, DateTimeConstants.FEBRUARY, 17));
-		test_days.add(calendarUtil.create(2010, DateTimeConstants.AUGUST, 30));
-		test_days.add(calendarUtil.create(2010, DateTimeConstants.APRIL, 2));
-		test_days.add(calendarUtil.create(2010, DateTimeConstants.APRIL, 5));
+				.add(LocalDate.of(2010, FEBRUARY, 17));
+		test_days.add(LocalDate.of(2010, AUGUST, 30));
+		test_days.add(LocalDate.of(2010, APRIL, 2));
+		test_days.add(LocalDate.of(2010, APRIL, 5));
 		test_days
-				.add(calendarUtil.create(2010, DateTimeConstants.NOVEMBER, 17));
+				.add(LocalDate.of(2010, NOVEMBER, 17));
 		test_days
-				.add(calendarUtil.create(2010, DateTimeConstants.NOVEMBER, 28));
-		test_days.add(calendarUtil.create(2010, DateTimeConstants.JANUARY, 1));
-		test_days.add(calendarUtil.create(2010, DateTimeConstants.JANUARY, 18));
+				.add(LocalDate.of(2010, NOVEMBER, 28));
+		test_days.add(LocalDate.of(2010, JANUARY, 1));
+		test_days.add(LocalDate.of(2010, JANUARY, 18));
 		test_days
-				.add(calendarUtil.create(2010, DateTimeConstants.NOVEMBER, 26));
+				.add(LocalDate.of(2010, NOVEMBER, 26));
 		test_days_l1.addAll(test_days);
-		test_days_l1.add(calendarUtil
-				.create(2010, DateTimeConstants.JANUARY, 2));
+		test_days_l1.add(LocalDate.of(2010, JANUARY, 2));
 		test_days_l2.addAll(test_days_l1);
-		test_days_l2.add(calendarUtil
-				.create(2010, DateTimeConstants.JANUARY, 3));
+		test_days_l2.add(LocalDate.of(2010, JANUARY, 3));
 
 		test_days_l11.addAll(test_days);
 		test_days_l11
-				.add(calendarUtil.create(2010, DateTimeConstants.JULY, 27));
-		test_days_l11.add(calendarUtil.create(2010, DateTimeConstants.JULY, 9));
-		test_days_l11.add(calendarUtil.create(2010, DateTimeConstants.FEBRUARY,
+				.add(LocalDate.of(2010, JULY, 27));
+		test_days_l11.add(LocalDate.of(2010, JULY, 9));
+		test_days_l11.add(LocalDate.of(2010, FEBRUARY,
 				26));
-		test_days_l11.add(calendarUtil.create(2010, DateTimeConstants.AUGUST,
+		test_days_l11.add(LocalDate.of(2010, AUGUST,
 				11));
-		test_days_l11.add(calendarUtil.create(2010,
-				DateTimeConstants.SEPTEMBER, 6));
-		test_days_l11.add(calendarUtil.create(2010,
-				DateTimeConstants.SEPTEMBER, 10));
-		test_days_l11.add(calendarUtil.create(2010, DateTimeConstants.NOVEMBER,
+		test_days_l11.add(LocalDate.of(2010,
+				SEPTEMBER, 6));
+		test_days_l11.add(LocalDate.of(2010,
+				SEPTEMBER, 10));
+		test_days_l11.add(LocalDate.of(2010, NOVEMBER,
 				17));
-		test_days_l11.add(calendarUtil.create(2010, DateTimeConstants.DECEMBER,
+		test_days_l11.add(LocalDate.of(2010, DECEMBER,
 				8));
-		test_days_l11.add(calendarUtil.create(2010, DateTimeConstants.DECEMBER,
+		test_days_l11.add(LocalDate.of(2010, DECEMBER,
 				17));
 	}
 
@@ -164,13 +169,14 @@ public class HolidayTest {
 
 	@Test
 	public void testIsHolidayPerformanceMultithreaded() throws Exception {
-		LocalDate date = calendarUtil.create(2010, 1, 1);
+		LocalDate date = LocalDate.of(2010, 1, 1);
 		final AtomicLong count = new AtomicLong(0);
 		final AtomicLong sumDuration = new AtomicLong(0);
 		ExecutorService executorService = Executors.newCachedThreadPool();
 		while (date.getYear() < 2013) {
 			final LocalDate localDate = date;
 			executorService.submit(new Runnable() {
+				@Override
 				public void run() {
 					long start = System.currentTimeMillis();
 					HolidayManager m = HolidayManager.getInstance("test");
@@ -201,17 +207,6 @@ public class HolidayTest {
 		Assert.assertFalse("This date should NOT be a holiday.", m.isHoliday(c));
 		c.add(Calendar.DAY_OF_YEAR, 1);
 		Assert.assertTrue("This date should be a holiday.", m.isHoliday(c));
-	}
-
-	@Test
-	public void testChronology() throws Exception {
-		ISOChronology isoChrono = ISOChronology.getInstanceUTC();
-		HolidayManager m = HolidayManager.getInstance("test");
-		Set<Holiday> holidays = m.getHolidays(2010);
-		for (Holiday d : holidays) {
-			Assert.assertEquals("Wrong chronology.", isoChrono, d.getDate()
-					.getChronology());
-		}
 	}
 
 	@Test
@@ -276,7 +271,7 @@ public class HolidayTest {
 
 	@Test
 	public void testHolidayDescription() {
-		Holiday h = new Holiday(calendarUtil.create(2011, 2, 2), "CHRISTMAS",
+		Holiday h = new Holiday(LocalDate.of(2011, 2, 2), "CHRISTMAS",
 				LocalizedHolidayType.OFFICIAL_HOLIDAY);
 		Assert.assertEquals("Wrong description", "Weihnachten",
 				h.getDescription());
@@ -288,19 +283,19 @@ public class HolidayTest {
 
 	@Test
 	public void testHolidayEquals() {
-		Holiday h1 = new Holiday(calendarUtil.create(2011, 2, 2), "CHRISTMAS",
+		Holiday h1 = new Holiday(LocalDate.of(2011, 2, 2), "CHRISTMAS",
 				LocalizedHolidayType.OFFICIAL_HOLIDAY);
 		Assert.assertTrue("Wrong equals implementation", h1.equals(h1));
-		Holiday h2b = new Holiday(calendarUtil.create(2011, 2, 2), new String(
+		Holiday h2b = new Holiday(LocalDate.of(2011, 2, 2), new String(
 				"CHRISTMAS"), LocalizedHolidayType.OFFICIAL_HOLIDAY);
 		Assert.assertTrue("Wrong equals implementation", h1.equals(h2b));
-		Holiday h2 = new Holiday(calendarUtil.create(2011, 2, 1), "CHRISTMAS",
+		Holiday h2 = new Holiday(LocalDate.of(2011, 2, 1), "CHRISTMAS",
 				LocalizedHolidayType.OFFICIAL_HOLIDAY);
 		Assert.assertFalse("Wrong equals implementation", h1.equals(h2));
-		Holiday h3 = new Holiday(calendarUtil.create(2011, 2, 2), "NEW_YEAR",
+		Holiday h3 = new Holiday(LocalDate.of(2011, 2, 2), "NEW_YEAR",
 				LocalizedHolidayType.OFFICIAL_HOLIDAY);
 		Assert.assertFalse("Wrong equals implementation", h1.equals(h3));
-		Holiday h4 = new Holiday(calendarUtil.create(2011, 2, 2), "CHRISTMAS",
+		Holiday h4 = new Holiday(LocalDate.of(2011, 2, 2), "CHRISTMAS",
 				LocalizedHolidayType.UNOFFICIAL_HOLIDAY);
 		Assert.assertFalse("Wrong equals implementation", h1.equals(h4));
 	}

--- a/src/test/java/de/jollyday/tests/HolidayUKTest.java
+++ b/src/test/java/de/jollyday/tests/HolidayUKTest.java
@@ -17,10 +17,9 @@ package de.jollyday.tests;
 
 import static org.junit.Assert.assertTrue;
 
+import java.time.LocalDate;
 import java.util.Set;
 
-import org.joda.time.LocalDate;
-import org.joda.time.chrono.ISOChronology;
 import org.junit.Test;
 
 import de.jollyday.Holiday;
@@ -55,8 +54,8 @@ public class HolidayUKTest extends AbstractCountryTestBase {
 	}
 
 	private void doChristmasContainmentTest(int year, int dayOfChristmas, int dayOfBoxingday) {
-		LocalDate christmas = new LocalDate(year, 12, dayOfChristmas, ISOChronology.getInstance());
-		LocalDate boxingday = new LocalDate(year, 12, dayOfBoxingday, ISOChronology.getInstance());
+		LocalDate christmas = LocalDate.of(year, 12, dayOfChristmas);
+		LocalDate boxingday = LocalDate.of(year, 12, dayOfBoxingday);
 		HolidayManager holidayManager = HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.UNITED_KINGDOM));
 		Set<Holiday> holidays = holidayManager.getHolidays(year);
 		assertTrue("There should be christmas on "+christmas, contains(christmas, holidays));

--- a/src/test/java/de/jollyday/tests/ISOCodesTest.java
+++ b/src/test/java/de/jollyday/tests/ISOCodesTest.java
@@ -119,7 +119,7 @@ public class ISOCodesTest {
 	private void compareL1WithL2(ResourceBundle l1, ResourceBundle l2) {
 		Locale locale = "".equals(l2.getLocale().getCountry()) ? Locale.ENGLISH : l2.getLocale();
 		Enumeration<String> keys = l1.getKeys();
-		Set<String> l2KeySet = new HashSet<String>(Collections.list(l2.getKeys()));
+		Set<String> l2KeySet = new HashSet<>(Collections.list(l2.getKeys()));
 		StringBuilder misses = new StringBuilder();
 		while (keys.hasMoreElements()) {
 			String propertyName = keys.nextElement();

--- a/src/test/java/de/jollyday/tests/UtilTest.java
+++ b/src/test/java/de/jollyday/tests/UtilTest.java
@@ -15,6 +15,13 @@
  */
 package de.jollyday.tests;
 
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
+import static java.time.Month.MARCH;
+import static java.time.Month.OCTOBER;
+import static java.time.Month.SEPTEMBER;
+
+import java.time.LocalDate;
 import java.util.Calendar;
 import java.util.HashSet;
 import java.util.Locale;
@@ -22,10 +29,6 @@ import java.util.Set;
 
 import junit.framework.Assert;
 
-import org.joda.time.DateTimeConstants;
-import org.joda.time.Interval;
-import org.joda.time.LocalDate;
-import org.joda.time.chrono.ISOChronology;
 import org.junit.Test;
 
 import de.jollyday.Holiday;
@@ -43,10 +46,10 @@ public class UtilTest {
 
 	@Test
 	public void testWeekend() {
-		LocalDate dateFriday = calendarUtil.create(2010, DateTimeConstants.MARCH, 12);
-		LocalDate dateSaturday = calendarUtil.create(2010, DateTimeConstants.MARCH, 13);
-		LocalDate dateSunday = calendarUtil.create(2010, DateTimeConstants.MARCH, 14);
-		LocalDate dateMonday = calendarUtil.create(2010, DateTimeConstants.MARCH, 15);
+		LocalDate dateFriday = LocalDate.of(2010, MARCH, 12);
+		LocalDate dateSaturday = LocalDate.of(2010, MARCH, 13);
+		LocalDate dateSunday = LocalDate.of(2010, MARCH, 14);
+		LocalDate dateMonday = LocalDate.of(2010, MARCH, 15);
 		Assert.assertFalse(calendarUtil.isWeekend(dateFriday));
 		Assert.assertTrue(calendarUtil.isWeekend(dateSaturday));
 		Assert.assertTrue(calendarUtil.isWeekend(dateSunday));
@@ -55,9 +58,9 @@ public class UtilTest {
 
 	@Test
 	public void testCalendarIslamicNewYear() {
-		Set<LocalDate> expected = new HashSet<LocalDate>();
-		expected.add(calendarUtil.create(2008, DateTimeConstants.JANUARY, 10));
-		expected.add(calendarUtil.create(2008, DateTimeConstants.DECEMBER, 29));
+		Set<LocalDate> expected = new HashSet<>();
+		expected.add(LocalDate.of(2008, JANUARY, 10));
+		expected.add(LocalDate.of(2008, DECEMBER, 29));
 		Set<LocalDate> holidays = calendarUtil.getIslamicHolidaysInGregorianYear(2008, 1, 1);
 		Assert.assertNotNull(holidays);
 		Assert.assertEquals("Wrong number of islamic new years in 2008.", expected.size(), holidays.size());
@@ -66,8 +69,8 @@ public class UtilTest {
 
 	@Test
 	public void testCalendarIslamicAschura2008() {
-		Set<LocalDate> expected = new HashSet<LocalDate>();
-		expected.add(calendarUtil.create(2008, DateTimeConstants.JANUARY, 19));
+		Set<LocalDate> expected = new HashSet<>();
+		expected.add(LocalDate.of(2008, JANUARY, 19));
 		Set<LocalDate> holidays = calendarUtil.getIslamicHolidaysInGregorianYear(2008, 1, 10);
 		Assert.assertNotNull(holidays);
 		Assert.assertEquals("Wrong number of islamic Aschura holidays in 2008.", expected.size(), holidays.size());
@@ -76,9 +79,9 @@ public class UtilTest {
 
 	@Test
 	public void testCalendarIslamicAschura2009() {
-		Set<LocalDate> expected = new HashSet<LocalDate>();
-		expected.add(calendarUtil.create(2009, DateTimeConstants.JANUARY, 7));
-		expected.add(calendarUtil.create(2009, DateTimeConstants.DECEMBER, 27));
+		Set<LocalDate> expected = new HashSet<>();
+		expected.add(LocalDate.of(2009, JANUARY, 7));
+		expected.add(LocalDate.of(2009, DECEMBER, 27));
 		Set<LocalDate> holidays = calendarUtil.getIslamicHolidaysInGregorianYear(2009, 1, 10);
 		Assert.assertNotNull(holidays);
 		Assert.assertEquals("Wrong number of islamic Aschura holidays in 2009.", expected.size(), holidays.size());
@@ -87,8 +90,8 @@ public class UtilTest {
 
 	@Test
 	public void testCalendarIslamicIdAlFitr2008() {
-		Set<LocalDate> expected = new HashSet<LocalDate>();
-		expected.add(calendarUtil.create(2008, DateTimeConstants.OCTOBER, 2));
+		Set<LocalDate> expected = new HashSet<>();
+		expected.add(LocalDate.of(2008, OCTOBER, 2));
 		Set<LocalDate> holidays = calendarUtil.getIslamicHolidaysInGregorianYear(2008, 10, 1);
 		Assert.assertNotNull(holidays);
 		Assert.assertEquals("Wrong number of islamic IdAlFitr holidays in 2008.", expected.size(), holidays.size());
@@ -97,8 +100,8 @@ public class UtilTest {
 
 	@Test
 	public void testCalendarIslamicIdAlFitr2009() {
-		Set<LocalDate> expected = new HashSet<LocalDate>();
-		expected.add(calendarUtil.create(2009, DateTimeConstants.SEPTEMBER, 21));
+		Set<LocalDate> expected = new HashSet<>();
+		expected.add(LocalDate.of(2009, SEPTEMBER, 21));
 		Set<LocalDate> holidays = calendarUtil.getIslamicHolidaysInGregorianYear(2009, 10, 1);
 		Assert.assertNotNull(holidays);
 		Assert.assertEquals("Wrong number of islamic IdAlFitr holidays in 2009.", expected.size(), holidays.size());
@@ -176,32 +179,25 @@ public class UtilTest {
 	}
 
 	private void checkEasterDate(Integer year, int month, int day) {
-		Assert.assertEquals("Wrong easter date.", calendarUtil.create(year, month, day),
+		Assert.assertEquals("Wrong easter date.", LocalDate.of(year, month, day),
 				calendarUtil.getEasterSunday(year));
 	}
 
 	@Test
 	public void testCalendarUtilEasterJulian() {
-		Assert.assertEquals("Wrong easter date.", calendarUtil.create(1583, 4, 10), calendarUtil.getEasterSunday(1583));
+		Assert.assertEquals("Wrong easter date.", LocalDate.of(1583, 4, 10), calendarUtil.getEasterSunday(1583));
 	}
 
 	@Test
 	public void testCalendarUtilEasterGregorian() {
-		Assert.assertEquals("Wrong easter date.", calendarUtil.create(1584, 4, 1), calendarUtil.getEasterSunday(1584));
-	}
-
-	@Test
-	public void testCalendarUtilToday() {
-		LocalDate today = new LocalDate(Calendar.getInstance(), ISOChronology.getInstance());
-		Assert.assertEquals("Wrong date.", today, calendarUtil.create());
+		Assert.assertEquals("Wrong easter date.", LocalDate.of(1584, 4, 1), calendarUtil.getEasterSunday(1584));
 	}
 
 	@Test
 	public void testUmlaut() {
-		final LocalDate aDate = calendarUtil.create(2010, DateTimeConstants.JANUARY, 6);
+		final LocalDate aDate = LocalDate.of(2010, JANUARY, 6);
 		final HolidayManager aMgr = HolidayManager.getInstance(HolidayCalendar.AUSTRIA);
-		final Set<Holiday> hs = aMgr.getHolidays(new Interval(aDate.toDateTimeAtStartOfDay(), aDate
-				.toDateTimeAtStartOfDay().plusDays(1)));
+		final Set<Holiday> hs = aMgr.getHolidays(aDate, aDate.plusDays(1));
 		Assert.assertNotNull(hs);
 		Assert.assertEquals(1, hs.size());
 		Assert.assertEquals("Heilige Drei K\u00F6nige", hs.iterator().next().getDescription(Locale.GERMANY));

--- a/src/test/java/de/jollyday/tests/UtilTest.java
+++ b/src/test/java/de/jollyday/tests/UtilTest.java
@@ -91,7 +91,7 @@ public class UtilTest {
 	@Test
 	public void testCalendarIslamicIdAlFitr2008() {
 		Set<LocalDate> expected = new HashSet<>();
-		expected.add(LocalDate.of(2008, OCTOBER, 2));
+		expected.add(LocalDate.of(2008, OCTOBER, 1));
 		Set<LocalDate> holidays = calendarUtil.getIslamicHolidaysInGregorianYear(2008, 10, 1);
 		Assert.assertNotNull(holidays);
 		Assert.assertEquals("Wrong number of islamic IdAlFitr holidays in 2008.", expected.size(), holidays.size());
@@ -101,7 +101,7 @@ public class UtilTest {
 	@Test
 	public void testCalendarIslamicIdAlFitr2009() {
 		Set<LocalDate> expected = new HashSet<>();
-		expected.add(LocalDate.of(2009, SEPTEMBER, 21));
+		expected.add(LocalDate.of(2009, SEPTEMBER, 20));
 		Set<LocalDate> holidays = calendarUtil.getIslamicHolidaysInGregorianYear(2009, 10, 1);
 		Assert.assertNotNull(holidays);
 		Assert.assertEquals("Wrong number of islamic IdAlFitr holidays in 2009.", expected.size(), holidays.size());

--- a/src/test/java/de/jollyday/tests/base/AbstractCountryTestBase.java
+++ b/src/test/java/de/jollyday/tests/base/AbstractCountryTestBase.java
@@ -60,7 +60,7 @@ public abstract class AbstractCountryTestBase {
 	 */
 	protected void compareData(HolidayManager expected, HolidayManager found, int year) {
 		CalendarHierarchy expectedHierarchy = expected.getCalendarHierarchy();
-		ArrayList<String> args = new ArrayList<String>();
+		ArrayList<String> args = new ArrayList<>();
 		compareDates(expected, found, expectedHierarchy, args, year);
 	}
 
@@ -75,7 +75,7 @@ public abstract class AbstractCountryTestBase {
 			}
 		}
 		for (String id : h.getChildren().keySet()) {
-			ArrayList<String> newArgs = new ArrayList<String>(args);
+			ArrayList<String> newArgs = new ArrayList<>(args);
 			newArgs.add(id);
 			compareDates(expected, found, h.getChildren().get(id), newArgs, year);
 		}

--- a/src/test/java/de/jollyday/tests/parsers/ChristianHolidayParserTest.java
+++ b/src/test/java/de/jollyday/tests/parsers/ChristianHolidayParserTest.java
@@ -15,13 +15,13 @@
  */
 package de.jollyday.tests.parsers;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.joda.time.LocalDate;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -43,7 +43,7 @@ public class ChristianHolidayParserTest {
 
 	@Test
 	public void testEmpty() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = new Holidays();
 		hp.parse(2010, holidays, config);
 		Assert.assertTrue("Expected to be empty.", holidays.isEmpty());
@@ -51,7 +51,7 @@ public class ChristianHolidayParserTest {
 
 	@Test
 	public void testEaster() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = createConfig(ChristianHolidayType.EASTER);
 		hp.parse(2011, holidays, config);
 		Assert.assertEquals("Wrong number of holidays.", 1, holidays.size());
@@ -62,7 +62,7 @@ public class ChristianHolidayParserTest {
 
 	@Test
 	public void testChristianInvalidDate() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = createConfig(ChristianHolidayType.EASTER);
 		config.getChristianHoliday().get(0).setValidTo(2010);
 		hp.parse(2011, holidays, config);
@@ -71,11 +71,11 @@ public class ChristianHolidayParserTest {
 
 	@Test
 	public void testRelativeToEasterSunday() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = createConfig(1);
 		RelativeToEasterSundayParser p = new RelativeToEasterSundayParser();
 		p.parse(2011, holidays, config);
-		List<LocalDate> expected = new ArrayList<LocalDate>();
+		List<LocalDate> expected = new ArrayList<>();
 		expected.add(calendarUtil.create(2011, 4, 25));
 		Assert.assertEquals("Wrong number of holidays.", expected.size(), holidays.size());
 		Assert.assertEquals("Wrong holiday.", expected.get(0), holidays.iterator().next().getDate());
@@ -83,13 +83,13 @@ public class ChristianHolidayParserTest {
 
 	@Test
 	public void testChristianDates() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = createConfig(ChristianHolidayType.EASTER, ChristianHolidayType.CLEAN_MONDAY,
 				ChristianHolidayType.EASTER_SATURDAY, ChristianHolidayType.EASTER_TUESDAY,
 				ChristianHolidayType.GENERAL_PRAYER_DAY, ChristianHolidayType.PENTECOST,
 				ChristianHolidayType.SACRED_HEART);
 		hp.parse(2011, holidays, config);
-		List<LocalDate> expected = new ArrayList<LocalDate>();
+		List<LocalDate> expected = new ArrayList<>();
 		expected.add(calendarUtil.create(2011, 3, 7));
 		expected.add(calendarUtil.create(2011, 4, 23));
 		expected.add(calendarUtil.create(2011, 4, 24));
@@ -101,7 +101,7 @@ public class ChristianHolidayParserTest {
 		Assert.assertEquals("Wrong number of holidays.", expected.size(), holidays.size());
 
 		Collections.sort(expected);
-		List<Holiday> found = new ArrayList<Holiday>(holidays);
+		List<Holiday> found = new ArrayList<>(holidays);
 		Collections.sort(found, new HolidayComparator());
 
 		for (int i = 0; i < expected.size(); i++) {

--- a/src/test/java/de/jollyday/tests/parsers/EthiopianOrthodoxHolidayParserTest.java
+++ b/src/test/java/de/jollyday/tests/parsers/EthiopianOrthodoxHolidayParserTest.java
@@ -15,10 +15,10 @@
  */
 package de.jollyday.tests.parsers;
 
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.joda.time.LocalDate;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -40,7 +40,7 @@ public class EthiopianOrthodoxHolidayParserTest {
 
 	@Test
 	public void testEmpty() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = new Holidays();
 		parser.parse(2010, holidays, config);
 		Assert.assertTrue("Expected to be empty.", holidays.isEmpty());
@@ -48,7 +48,7 @@ public class EthiopianOrthodoxHolidayParserTest {
 
 	@Test
 	public void testAllHolidays() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = new Holidays();
 		config.getEthiopianOrthodoxHoliday().add(createHoliday(EthiopianOrthodoxHolidayType.ENKUTATASH));
 		config.getEthiopianOrthodoxHoliday().add(createHoliday(EthiopianOrthodoxHolidayType.MESKEL));

--- a/src/test/java/de/jollyday/tests/parsers/FixedParserTest.java
+++ b/src/test/java/de/jollyday/tests/parsers/FixedParserTest.java
@@ -15,6 +15,7 @@
  */
 package de.jollyday.tests.parsers;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -22,7 +23,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.joda.time.LocalDate;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -49,9 +49,9 @@ public class FixedParserTest {
 	public void testFixedWithValidity() {
 		Holidays h = createHolidays(createFixed(1, Month.JANUARY), createFixed(3, Month.MARCH),
 				createFixed(5, Month.MAY, 2011, null));
-		Set<Holiday> set = new HashSet<Holiday>();
+		Set<Holiday> set = new HashSet<>();
 		fixedParser.parse(2010, set, h);
-		containsAll(new ArrayList<Holiday>(set), calendarUtil.create(2010, 1, 1), calendarUtil.create(2010, 3, 3));
+		containsAll(new ArrayList<>(set), calendarUtil.create(2010, 1, 1), calendarUtil.create(2010, 3, 3));
 	}
 
 	@Test
@@ -59,9 +59,9 @@ public class FixedParserTest {
 		Holidays h = createHolidays(
 				createFixed(8, Month.JANUARY, createMoving(Weekday.SATURDAY, With.PREVIOUS, Weekday.FRIDAY)),
 				createFixed(23, Month.JANUARY, createMoving(Weekday.SUNDAY, With.NEXT, Weekday.MONDAY)));
-		Set<Holiday> set = new HashSet<Holiday>();
+		Set<Holiday> set = new HashSet<>();
 		fixedParser.parse(2011, set, h);
-		containsAll(new ArrayList<Holiday>(set), calendarUtil.create(2011, 1, 7), calendarUtil.create(2011, 1, 24));
+		containsAll(new ArrayList<>(set), calendarUtil.create(2011, 1, 7), calendarUtil.create(2011, 1, 24));
 	}
 
 	@Test
@@ -70,7 +70,7 @@ public class FixedParserTest {
 		fixed.setValidFrom(2010);
 		fixed.setEvery("2_YEARS");
 		Holidays holidays = createHolidays(fixed);
-		Set<Holiday> set = new HashSet<Holiday>();
+		Set<Holiday> set = new HashSet<>();
 		fixedParser.parse(2011, set, holidays);
 		Assert.assertTrue("Expected to be empty.", set.isEmpty());
 	}
@@ -81,14 +81,14 @@ public class FixedParserTest {
 		fixed.setValidFrom(2010);
 		fixed.setEvery("3_YEARS");
 		Holidays holidays = createHolidays(fixed);
-		Set<Holiday> set = new HashSet<Holiday>();
+		Set<Holiday> set = new HashSet<>();
 		fixedParser.parse(2013, set, holidays);
 		Assert.assertEquals("Wrong number of holidays.", 1, set.size());
 	}
 
 	private void containsAll(List<Holiday> list, LocalDate... dates) {
 		Assert.assertEquals("Number of holidays.", dates.length, list.size());
-		List<LocalDate> expected = new ArrayList<LocalDate>(Arrays.asList(dates));
+		List<LocalDate> expected = new ArrayList<>(Arrays.asList(dates));
 		Collections.sort(expected);
 		Collections.sort(list, new HolidayComparator());
 		for (int i = 0; i < expected.size(); i++) {

--- a/src/test/java/de/jollyday/tests/parsers/FixedWeekdayBetweenFixedParserTest.java
+++ b/src/test/java/de/jollyday/tests/parsers/FixedWeekdayBetweenFixedParserTest.java
@@ -40,7 +40,7 @@ public class FixedWeekdayBetweenFixedParserTest extends FixedParserTest {
 
 	@Test
 	public void testEmpty() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = new Holidays();
 		parser.parse(2010, holidays, config);
 		Assert.assertTrue("Expected to be empty.", holidays.isEmpty());
@@ -48,7 +48,7 @@ public class FixedWeekdayBetweenFixedParserTest extends FixedParserTest {
 
 	@Test
 	public void testInvalid() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = new Holidays();
 		FixedWeekdayBetweenFixed e = new FixedWeekdayBetweenFixed();
 		e.setValidTo(2009);
@@ -59,7 +59,7 @@ public class FixedWeekdayBetweenFixedParserTest extends FixedParserTest {
 
 	@Test
 	public void testWednesday() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = new Holidays();
 		FixedWeekdayBetweenFixed e = new FixedWeekdayBetweenFixed();
 		e.setFrom(createFixed(17, Month.JANUARY));

--- a/src/test/java/de/jollyday/tests/parsers/FixedWeekdayInMonthParserTest.java
+++ b/src/test/java/de/jollyday/tests/parsers/FixedWeekdayInMonthParserTest.java
@@ -36,7 +36,7 @@ public class FixedWeekdayInMonthParserTest {
 
 	@Test
 	public void testEmpty() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = new Holidays();
 		parser.parse(2010, holidays, config);
 		Assert.assertTrue("Expected to be empty.", holidays.isEmpty());
@@ -44,7 +44,7 @@ public class FixedWeekdayInMonthParserTest {
 
 	@Test
 	public void testInvalid() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = new Holidays();
 		FixedWeekdayInMonth e = new FixedWeekdayInMonth();
 		e.setValidFrom(2011);

--- a/src/test/java/de/jollyday/tests/parsers/FixedWeekdayRelativeToFixedParserTest.java
+++ b/src/test/java/de/jollyday/tests/parsers/FixedWeekdayRelativeToFixedParserTest.java
@@ -44,7 +44,7 @@ public class FixedWeekdayRelativeToFixedParserTest {
 
 	@Test
 	public void testEmpty() {
-		Set<Holiday> result = new HashSet<Holiday>();
+		Set<Holiday> result = new HashSet<>();
 		Holidays config = new Holidays();
 		fwrtf.parse(2011, result, config);
 		Assert.assertTrue("Result is not empty.", result.isEmpty());
@@ -52,7 +52,7 @@ public class FixedWeekdayRelativeToFixedParserTest {
 
 	@Test
 	public void testInvalid() {
-		Set<Holiday> result = new HashSet<Holiday>();
+		Set<Holiday> result = new HashSet<>();
 		Holidays config = new Holidays();
 		FixedWeekdayRelativeToFixed rule = new FixedWeekdayRelativeToFixed();
 		rule.setWhich(Which.FIRST);
@@ -70,7 +70,7 @@ public class FixedWeekdayRelativeToFixedParserTest {
 
 	@Test
 	public void testParserFirstBefore() {
-		Set<Holiday> result = new HashSet<Holiday>();
+		Set<Holiday> result = new HashSet<>();
 		Holidays config = new Holidays();
 		FixedWeekdayRelativeToFixed rule = new FixedWeekdayRelativeToFixed();
 		rule.setWhich(Which.FIRST);
@@ -88,7 +88,7 @@ public class FixedWeekdayRelativeToFixedParserTest {
 
 	@Test
 	public void testParserSecondBefore() {
-		Set<Holiday> result = new HashSet<Holiday>();
+		Set<Holiday> result = new HashSet<>();
 		Holidays config = new Holidays();
 		FixedWeekdayRelativeToFixed rule = new FixedWeekdayRelativeToFixed();
 		rule.setWhich(Which.SECOND);
@@ -106,7 +106,7 @@ public class FixedWeekdayRelativeToFixedParserTest {
 
 	@Test
 	public void testParserThirdAfter() {
-		Set<Holiday> result = new HashSet<Holiday>();
+		Set<Holiday> result = new HashSet<>();
 		Holidays config = new Holidays();
 		FixedWeekdayRelativeToFixed rule = new FixedWeekdayRelativeToFixed();
 		rule.setWhich(Which.THIRD);
@@ -124,7 +124,7 @@ public class FixedWeekdayRelativeToFixedParserTest {
 
 	@Test
 	public void testParserFourthAfter() {
-		Set<Holiday> result = new HashSet<Holiday>();
+		Set<Holiday> result = new HashSet<>();
 		Holidays config = new Holidays();
 		FixedWeekdayRelativeToFixed rule = new FixedWeekdayRelativeToFixed();
 		rule.setWhich(Which.FOURTH);

--- a/src/test/java/de/jollyday/tests/parsers/HolidayComparator.java
+++ b/src/test/java/de/jollyday/tests/parsers/HolidayComparator.java
@@ -28,6 +28,7 @@ public class HolidayComparator implements Comparator<Holiday>, Serializable {
 
 	private static final long serialVersionUID = 7346124638993088797L;
 
+	@Override
 	public int compare(Holiday o1, Holiday o2) {
 		return o1.getDate().compareTo(o2.getDate());
 	}

--- a/src/test/java/de/jollyday/tests/parsers/RelativeToEasterSundayParserTest.java
+++ b/src/test/java/de/jollyday/tests/parsers/RelativeToEasterSundayParserTest.java
@@ -1,23 +1,23 @@
 package de.jollyday.tests.parsers;
 
-import de.jollyday.config.*;
-
 import static org.junit.Assert.*;
 
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.joda.time.LocalDate;
 import org.junit.Test;
 
 import de.jollyday.Holiday;
+import de.jollyday.config.Holidays;
+import de.jollyday.config.RelativeToEasterSunday;
 import de.jollyday.parser.impl.RelativeToEasterSundayParser;
 import de.jollyday.util.CalendarUtil;
 
 public class RelativeToEasterSundayParserTest {
 
 	RelativeToEasterSundayParser parser = new RelativeToEasterSundayParser();
-	Set<Holiday> holidays = new HashSet<Holiday>();	
+	Set<Holiday> holidays = new HashSet<>();	
 	CalendarUtil calendarUtil = new CalendarUtil();
 	
 	@Test

--- a/src/test/java/de/jollyday/tests/parsers/RelativeToFixedParserTest.java
+++ b/src/test/java/de/jollyday/tests/parsers/RelativeToFixedParserTest.java
@@ -42,7 +42,7 @@ public class RelativeToFixedParserTest {
 
 	@Test
 	public void testEmpty() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = new Holidays();
 		rtfp.parse(2010, holidays, config);
 		Assert.assertTrue("Expected to be empty.", holidays.isEmpty());
@@ -50,7 +50,7 @@ public class RelativeToFixedParserTest {
 
 	@Test
 	public void testInvalid() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = new Holidays();
 		RelativeToFixed rule = new RelativeToFixed();
 		rule.setValidFrom(2011);
@@ -61,7 +61,7 @@ public class RelativeToFixedParserTest {
 
 	@Test
 	public void testWeekday() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = new Holidays();
 		RelativeToFixed rule = new RelativeToFixed();
 		rule.setWeekday(Weekday.THURSDAY);
@@ -78,7 +78,7 @@ public class RelativeToFixedParserTest {
 
 	@Test
 	public void testNumberOfDays() {
-		Set<Holiday> holidays = new HashSet<Holiday>();
+		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = new Holidays();
 		RelativeToFixed rule = new RelativeToFixed();
 		rule.setDays(3);

--- a/src/test/java/de/jollyday/tests/parsers/RelativeToWeekdayInMonthParserTest.java
+++ b/src/test/java/de/jollyday/tests/parsers/RelativeToWeekdayInMonthParserTest.java
@@ -44,7 +44,7 @@ public class RelativeToWeekdayInMonthParserTest {
 
 	@Test
 	public void testEmpty() {
-		Set<Holiday> result = new HashSet<Holiday>();
+		Set<Holiday> result = new HashSet<>();
 		Holidays config = new Holidays();
 		rtwim.parse(2011, result, config);
 		Assert.assertTrue("Result is not empty.", result.isEmpty());
@@ -52,7 +52,7 @@ public class RelativeToWeekdayInMonthParserTest {
 
 	@Test
 	public void testInvalid() {
-		Set<Holiday> result = new HashSet<Holiday>();
+		Set<Holiday> result = new HashSet<>();
 		Holidays config = new Holidays();
 		RelativeToWeekdayInMonth rule = new RelativeToWeekdayInMonth();
 		rule.setWeekday(Weekday.TUESDAY);
@@ -70,7 +70,7 @@ public class RelativeToWeekdayInMonthParserTest {
 
 	@Test
 	public void testTueAfter2ndMondayJuly() {
-		Set<Holiday> result = new HashSet<Holiday>();
+		Set<Holiday> result = new HashSet<>();
 		Holidays config = new Holidays();
 		RelativeToWeekdayInMonth rule = new RelativeToWeekdayInMonth();
 		rule.setWeekday(Weekday.TUESDAY);

--- a/src/test/resources/holidays/Holidays_test_al_2010.xml
+++ b/src/test/resources/holidays/Holidays_test_al_2010.xml
@@ -10,7 +10,7 @@
 	  <tns:Fixed month="NOVEMBER" day="29"/>
 	  <tns:Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
 	  <tns:Fixed month="APRIL" day="5"/>
-	  <tns:Fixed month="NOVEMBER" day="17"/>
+	  <tns:Fixed month="NOVEMBER" day="16"/>
 	  <tns:Fixed month="SEPTEMBER" day="10"/>
   </tns:Holidays>
 </tns:Configuration>

--- a/src/test/resources/holidays/Holidays_test_es_2010.xml
+++ b/src/test/resources/holidays/Holidays_test_es_2010.xml
@@ -31,7 +31,7 @@
 		<tns:Fixed month="AUGUST" day="15"/>
   		<tns:Fixed month="SEPTEMBER" day="2"/>
   		<tns:Fixed month="APRIL" day="1" />
-  		<tns:Fixed month="NOVEMBER" day="17" />
+  		<tns:Fixed month="NOVEMBER" day="16" />
   	</tns:Holidays>
  </tns:SubConfigurations>
  <tns:SubConfigurations hierarchy="ml" description="Melilla">
@@ -39,7 +39,7 @@
   		<tns:Fixed month="MARCH" day="19"/>
 		<tns:Fixed month="AUGUST" day="15"/>
   		<tns:Fixed month="APRIL" day="1" />
-  		<tns:Fixed month="NOVEMBER" day="17" />
+  		<tns:Fixed month="NOVEMBER" day="16" />
   	</tns:Holidays>
  </tns:SubConfigurations>
  <tns:SubConfigurations hierarchy="cl" description="Castile and Leon">


### PR DESCRIPTION
I did the bare minimum changes to eliminate Joda-Time and use java.time instead. There are many optimizations that are now possible with the new API, but this can be done in a second round.

It seems most project files use LF while tests used CRLF, hence the huge diff for tests.

Regards,
Michael