### PR TITLE
Update documentation to not use deprecated method

### DIFF
--- a/src/site/apt/usage.apt
+++ b/src/site/apt/usage.apt
@@ -8,7 +8,8 @@ Code Example
  [[3]] To get a <<<HolidayManager>>> instance for US holidays:
   
 -----------------------
-HolidayManager m = HolidayManager.getInstance(HolidayCalendar.UNITED_STATES);
+ManagerParameter params = ManagerParameters.create(HolidayCalendar.UNITED_STATES);
+HolidayManager m = HolidayManager.getInstance(params);
 
 or
 


### PR DESCRIPTION
Hi,

since in my current project all compiler warnings are converted to errors I couldn't create a manager as indicated in the usage section of the website.

It took my a little while to figure out how to do it properly (and there isn't an example anywhere on the web). I would like to add it to the documentation so other people don't have to do it again.

Thanks for your work,
Leonard