### PR TITLE
Optional German holidays, descriptions

### DIFF
--- a/src/main/resources/holidays/Holidays_de.xml
+++ b/src/main/resources/holidays/Holidays_de.xml
@@ -7,6 +7,8 @@
 	  <tns:Fixed month="OCTOBER" day="3" validFrom="1990"  descriptionPropertiesKey="UNIFICATION"/>
 	  <tns:Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
 	  <tns:Fixed month="DECEMBER" day="26" descriptionPropertiesKey="STEPHENS"/>
+	  <tns:Fixed month="DECEMBER" day="24" descriptionPropertiesKey="CHRISTMAS_EVE" localizedType="UNOFFICIAL_HOLIDAY"/>
+	  <tns:Fixed month="DECEMBER" day="31" descriptionPropertiesKey="NEW_YEARS_EVE" localizedType="UNOFFICIAL_HOLIDAY"/>
       <tns:ChristianHoliday type="EASTER" />
 	  <tns:ChristianHoliday type="GOOD_FRIDAY"/>
 	  <tns:ChristianHoliday type="EASTER_MONDAY"/>

--- a/src/main/resources/holidays/Holidays_de.xml
+++ b/src/main/resources/holidays/Holidays_de.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tns:Configuration hierarchy="de" description="Germany" xmlns:tns="http://www.example.org/Holiday" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.example.org/Holiday /Holiday.xsd">
+<tns:Configuration hierarchy="de" description="Deutschland" xmlns:tns="http://www.example.org/Holiday" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.example.org/Holiday /Holiday.xsd">
   <tns:Holidays>
 	  <tns:Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
 	  <tns:Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
@@ -32,7 +32,7 @@
   		<tns:Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="ALL_SAINTS"/>
   		<tns:ChristianHoliday type="CORPUS_CHRISTI" />
   	</tns:Holidays>
-  	<tns:SubConfigurations hierarchy="mu" description="Munich">
+  	<tns:SubConfigurations hierarchy="mu" description="München">
   		<tns:Holidays>
   			<tns:Fixed day="15" month="AUGUST" descriptionPropertiesKey="ASSUMPTION_DAY"/>
   		</tns:Holidays>


### PR DESCRIPTION
As they are considered inofficial holidays in Germany under many circumstances, I suggest to add Christmas' eve and New Year's eve as unofficial holidays.

Also, I propose to use local naming for all descriptions in a file and provide a translation for the missing. Otherwise, all <SubConfigurations/> should be checked for English names (e.g. Bavarian, Nuremberg, Saxony, Northrhine-Westfalia, etc.).