### PR TITLE
Added Good Friday into czech holidays to reflect changes to the legislation.

### DIFF
--- a/src/main/resources/holidays/Holidays_cz.xml
+++ b/src/main/resources/holidays/Holidays_cz.xml
@@ -12,6 +12,7 @@
 	  <tns:Fixed month="DECEMBER" day="24" descriptionPropertiesKey="CHRISTMAS_EVE"/>
 	  <tns:Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
 	  <tns:Fixed month="DECEMBER" day="26" descriptionPropertiesKey="STEPHENS"/>
+	  <tns:ChristianHoliday type="GOOD_FRIDAY" validFrom="2016"/>
 	  <tns:ChristianHoliday type="EASTER" />
 	  <tns:ChristianHoliday type="EASTER_MONDAY"/>
   </tns:Holidays>


### PR DESCRIPTION
Since 2016, Good Friday is declared a public holiday in Czech republic.