### PR TITLE
Added support for "Saint-Jean-Baptiste" Public Holiday for Quebec,Canada.

### DIFF
--- a/src/main/resources/holidays/Holidays_ca.xml
+++ b/src/main/resources/holidays/Holidays_ca.xml
@@ -33,6 +33,7 @@
   </tns:SubConfigurations>
   <tns:SubConfigurations hierarchy="qc" description="Quebec">
   	<tns:Holidays>
+  		<tns:Fixed month="JUNE" day="24" descriptionPropertiesKey="SAINT_JEAN_BAPTISTE_DAY"/>
   		<tns:RelativeToFixed descriptionPropertiesKey="VICTORIA_DAY">
   			<tns:Weekday>MONDAY</tns:Weekday>
   			<tns:When>BEFORE</tns:When>


### PR DESCRIPTION
- Saint-Jean-Baptiste Day is a public holiday observed in Quebec, Canada annually on June 24th.
https://en.wikipedia.org/wiki/Saint-Jean-Baptiste_Day
