### PR TITLE
Corrected Swedish calendar configuration and added test.

### DIFF
--- a/src/main/resources/holidays/Holidays_se.xml
+++ b/src/main/resources/holidays/Holidays_se.xml
@@ -16,7 +16,7 @@
 		<tns:ChristianHoliday type="EASTER_MONDAY" />
 		<tns:ChristianHoliday type="ASCENSION_DAY" />
 		<tns:ChristianHoliday type="PENTECOST" />
-		<tns:FixedWeekdayBetweenFixed weekday="SATURDAY" descriptionPropertiesKey="MIDSUMMER_EVE">
+		<tns:FixedWeekdayBetweenFixed weekday="FRIDAY" descriptionPropertiesKey="MIDSUMMER_EVE">
 			<tns:from month="JUNE" day="19"/>
 			<tns:to month="JUNE" day="25"/>
 		</tns:FixedWeekdayBetweenFixed>

--- a/src/test/java/de/jollyday/tests/HolidaySETest.java
+++ b/src/test/java/de/jollyday/tests/HolidaySETest.java
@@ -1,0 +1,17 @@
+package de.jollyday.tests;
+
+import org.junit.Test;
+
+import de.jollyday.tests.base.AbstractCountryTestBase;
+
+public class HolidaySETest extends AbstractCountryTestBase {
+
+    private static final String ISO_CODE = "se";
+    private static final int YEAR = 2016;
+
+    @Test
+    public void testManagerSEStructure() throws Exception {
+        validateCalendarData(ISO_CODE, YEAR);
+    }
+
+}

--- a/src/test/resources/holidays/Holidays_test_se_2016.xml
+++ b/src/test/resources/holidays/Holidays_test_se_2016.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tns:Configuration hierarchy="se" description="Sweden" xmlns:tns="http://www.example.org/Holiday"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.example.org/Holiday /Holiday.xsd">
+    <tns:Holidays>
+        <tns:Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEARS_DAY"/>
+        <tns:Fixed month="JANUARY" day="6" descriptionPropertiesKey="EPIPHANY"/>
+        <tns:Fixed month="MARCH" day="25" descriptionPropertiesKey="GOOD_FRIDAY"/>
+        <tns:Fixed month="MARCH" day="27" descriptionPropertiesKey="EASTER"/>
+        <tns:Fixed month="MARCH" day="28" descriptionPropertiesKey="EASTER_MONDAY"/>
+        <tns:Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
+        <tns:Fixed month="MAY" day="5" descriptionPropertiesKey="ASCENSION"/>
+        <tns:Fixed month="MAY" day="15" descriptionPropertiesKey="PENTECOST"/>
+        <tns:Fixed month="JUNE" day="6" descriptionPropertiesKey="NATIONAL_DAY"/>
+        <tns:Fixed month="JUNE" day="24" descriptionPropertiesKey="MIDSUMMERS_EVE"/>
+        <tns:Fixed month="JUNE" day="25" descriptionPropertiesKey="MIDSUMMERS_DAY"/>
+        <tns:Fixed month="NOVEMBER" day="5" descriptionPropertiesKey="ALL_SAINTS_DAY"/>
+        <tns:Fixed month="DECEMBER" day="24" descriptionPropertiesKey="CHRISTMAS_EVE"/>
+        <tns:Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
+        <tns:Fixed month="DECEMBER" day="26" descriptionPropertiesKey="BOXING_DAY"/>
+        <tns:Fixed month="DECEMBER" day="31" descriptionPropertiesKey="NEW_YEARS_EVE"/>
+    </tns:Holidays>
+</tns:Configuration>


### PR DESCRIPTION
Midsummer eve is always on a friday (https://sv.wikipedia.org/wiki/Midsommar).