### PR TITLE
Fix relativetofixed parser

### DIFF
--- a/src/main/java/de/jollyday/parser/impl/RelativeToFixedParser.java
+++ b/src/main/java/de/jollyday/parser/impl/RelativeToFixedParser.java
@@ -52,6 +52,8 @@ public class RelativeToFixedParser extends AbstractHolidayParser {
 				// if weekday is set -> move to weekday
 				DayOfWeek day = xmlUtil.getWeekday(rf.getWeekday());
 				int direction = (rf.getWhen() == When.BEFORE ? -1 : 1);
+				// don't test start day
+				fixed = fixed.plusDays(direction);
 				while (fixed.getDayOfWeek() != day){
 					fixed = fixed.plusDays(direction);
 				}

--- a/src/test/java/de/jollyday/tests/parsers/RelativeToFixedParserTest.java
+++ b/src/test/java/de/jollyday/tests/parsers/RelativeToFixedParserTest.java
@@ -77,6 +77,23 @@ public class RelativeToFixedParserTest {
 	}
 
 	@Test
+	public void testSameWeekday() {
+		Set<Holiday> holidays = new HashSet<>();
+		Holidays config = new Holidays();
+		RelativeToFixed rule = new RelativeToFixed();
+		rule.setWeekday(Weekday.WEDNESDAY);
+		rule.setWhen(When.BEFORE);
+		Fixed date = new Fixed();
+		date.setDay(23);
+		date.setMonth(Month.NOVEMBER);
+		rule.setDate(date);
+		config.getRelativeToFixed().add(rule);
+		rtfp.parse(2016, holidays, config);
+		Assert.assertEquals("Number of holidays wrong.", 1, holidays.size());
+		Assert.assertEquals("Wrong date.", calendarUtil.create(2016, 11, 16), holidays.iterator().next().getDate());
+	}
+	
+	@Test
 	public void testNumberOfDays() {
 		Set<Holiday> holidays = new HashSet<>();
 		Holidays config = new Holidays();


### PR DESCRIPTION
The latest version of JollyDay has a bug concerning the RelativeToFixed rule.

All holidays with this relation (Repentance Prayer Day for Saxony/Germany and Victoria Day for Canada) are affected.

Example: Repentance Prayer Day in Saxony/Germany
Rule: Wednesday before 2016-11-23
Result: 23st is a Wednesday so current output is 2016-11-23
Should be: 2016-11-16 (proper date)

Same case for Victoria Day on 2015-05-25. Output is 2015-05-25 but it should be 2015-05-18.

If there someday is a holiday which requires this function as currently implemented, we would propose a second rule RelativeToFixedInclusive or similar.