### PR TITLE
Add method to create ManagerParameter from Locale

### DIFF
--- a/src/main/java/de/jollyday/ManagerParameters.java
+++ b/src/main/java/de/jollyday/ManagerParameters.java
@@ -8,14 +8,18 @@ import de.jollyday.parameter.CalendarPartManagerParameter;
 import de.jollyday.parameter.UrlManagerParameter;
 
 public final class ManagerParameters {
-	
+
 	private ManagerParameters(){
 	}
 	
 	public static ManagerParameter create(String calendarPart){
 		return create(calendarPart, null);
 	}
-		
+
+	public static ManagerParameter create(Locale lc) {
+		return create(lc.getCountry().toLowerCase(), null);
+	}
+
 	public static ManagerParameter create(HolidayCalendar calendar){
 		return create(calendar, null);
 	}
@@ -34,8 +38,8 @@ public final class ManagerParameters {
 
 	public static ManagerParameter create(URL calendarFileUrl, Properties properties){
 		return new UrlManagerParameter(calendarFileUrl, properties);
-	}	
-	
+	}
+
 	private static String prepareCalendarName(String calendar) {
 		if (calendar == null || "".equals(calendar.trim())) {
 			calendar = Locale.getDefault().getCountry().toLowerCase();

--- a/src/test/java/de/jollyday/parameter/ManagerParametersTest.java
+++ b/src/test/java/de/jollyday/parameter/ManagerParametersTest.java
@@ -1,0 +1,24 @@
+package de.jollyday.parameter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import de.jollyday.HolidayManager;
+import de.jollyday.ManagerParameter;
+import de.jollyday.ManagerParameters;
+import java.util.Calendar;
+import java.util.Locale;
+import org.junit.Test;
+
+public class ManagerParametersTest {
+    @Test
+    public void testCreateParameterFromLocale() {
+        ManagerParameter params = ManagerParameters.create(Locale.GERMANY);
+        HolidayManager manager = HolidayManager.getInstance(params);
+        assertEquals(Locale.GERMANY.getCountry().toLowerCase(), manager.getCalendarHierarchy().getId());
+        Calendar thirdOfOctober = Calendar.getInstance();
+        thirdOfOctober.set(Calendar.MONTH, Calendar.OCTOBER);
+        thirdOfOctober.set(Calendar.DAY_OF_MONTH, 3);
+        assertTrue("Oct 3rd should be a holiday in " + Locale.GERMANY, manager.isHoliday(thirdOfOctober));
+    }
+}


### PR DESCRIPTION
This change adds a way to create `ManagerParameter` from a `Locale`. This is an attempt to fix my issue #38 .

I tried to find the right place to add the method, but because I'm just starting to use Jollyday I'm not quite sure if the `ManagerParameters` is the correct place to do so. Please suggest a better place if I messed this up.