### PR TITLE
Add OSGi support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 # Ignore the maven target directory
 target/
 
+# Ignore eclipse files
+.classpath
+.settings/
+.project

--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,1 @@
+Export-Package: de.jollyday*

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,16 @@
                     <artifactId>cobertura-maven-plugin</artifactId>
                     <version>2.7</version>
                 </plugin>
+                <plugin>
+                    <groupId>biz.aQute.bnd</groupId>
+                    <artifactId>bnd-maven-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -178,6 +188,28 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.0.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -192,7 +192,6 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -204,7 +203,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.5</version>
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/src/main/java/de/jollyday/configuration/impl/DefaultConfigurationProvider.java
+++ b/src/main/java/de/jollyday/configuration/impl/DefaultConfigurationProvider.java
@@ -17,6 +17,7 @@ package de.jollyday.configuration.impl;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.util.Properties;
 import java.util.logging.Logger;
 
@@ -57,7 +58,11 @@ public class DefaultConfigurationProvider implements ConfigurationProvider {
 		try {
 			InputStream stream = null;
 			try {
-				stream = resourceUtil.getResource(CONFIG_FILE).openStream();
+				URL config = resourceUtil.getResource(CONFIG_FILE);
+				if (config == null) {
+				    throw new IllegalStateException("Properties file " + CONFIG_FILE + " not found on classpath");
+				}
+                                stream = config.openStream();
 				if (stream != null) {
 					properties.load(stream);
 				} else {

--- a/src/main/java/de/jollyday/datasource/ConfigurationDataSourceManager.java
+++ b/src/main/java/de/jollyday/datasource/ConfigurationDataSourceManager.java
@@ -37,7 +37,7 @@ public class ConfigurationDataSourceManager {
 	private ConfigurationDataSource instantiateDataSource(
 			String dataSourceClassName) {
 		try{
-			Class<?> dataSourceClass = classLoadingUtil.getClassloader().loadClass(dataSourceClassName);
+			Class<?> dataSourceClass = classLoadingUtil.loadClass(dataSourceClassName);
 			return ConfigurationDataSource.class.cast(dataSourceClass.newInstance());
 		}catch(Exception e){
 			throw new IllegalStateException("Cannot instantiate datasource instance of "+dataSourceClassName,e);

--- a/src/main/java/de/jollyday/util/ResourceUtil.java
+++ b/src/main/java/de/jollyday/util/ResourceUtil.java
@@ -203,9 +203,10 @@ public class ResourceUtil {
 	 */
 	public URL getResource(String resourceName) {
 		try {
-			return classLoadingUtil.getClassloader().getResource(resourceName);
+			URL resource = classLoadingUtil.getClassloader().getResource(resourceName);
+			return resource == null ? this.getClass().getClassLoader().getResource(resourceName) : resource;
 		} catch (Exception e) {
-			throw new IllegalStateException("Cannot load resource: " + resourceName, e);
+		    throw new IllegalStateException("Cannot load resource: " + resourceName, e);
 		}
 	}
 


### PR DESCRIPTION
I added the necessary plugins and config to create an OSGi bundle during the build. This should not influence usage outside of OSGi.

You can install in OSGi by downloading and installing apache karaf 4.1.1 and issue these commands:
install -s mvn:org.threeten/threeten-extra/1.2
install -s mvn:de.jollyday/jollyday/0.5.3-SNAPSHOT

The bundles should start without issues.
