### PR TITLE
#57 Add Good Friday to the Hungarian holidays

### DIFF
--- a/src/main/resources/holidays/Holidays_hu.xml
+++ b/src/main/resources/holidays/Holidays_hu.xml
@@ -13,6 +13,7 @@
 		<tns:Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
 		<tns:Fixed month="DECEMBER" day="26" descriptionPropertiesKey="STEPHENS"/>
 		<tns:ChristianHoliday type="EASTER" />
+		<tns:ChristianHoliday type="GOOD_FRIDAY" validFrom="2017" />
 		<tns:ChristianHoliday type="EASTER_MONDAY" />
 		<tns:ChristianHoliday type="WHIT_MONDAY" />
 	</tns:Holidays>


### PR DESCRIPTION
Good Friday is a holiday in Hungary [since 2017](http://hungarytoday.hu/news/official-good-friday-voted-become-hungarys-eleventh-public-holiday-89938).