### PR TITLE
Use System.getProperty instead of System.getProperties

### DIFF
--- a/src/main/java/de/jollyday/configuration/ConfigurationProviderManager.java
+++ b/src/main/java/de/jollyday/configuration/ConfigurationProviderManager.java
@@ -20,7 +20,6 @@ import de.jollyday.configuration.impl.DefaultConfigurationProvider;
 import de.jollyday.configuration.impl.URLConfigurationProvider;
 import de.jollyday.util.ClassLoadingUtil;
 
-import java.util.Properties;
 import java.util.logging.Logger;
 
 /**
@@ -57,8 +56,7 @@ public class ConfigurationProviderManager {
 	}
 
 	private void addCustomConfigurationProviderProperties(ManagerParameter parameter) {
-		Properties systemProps = System.getProperties();
-		String providersStrList = systemProps.getProperty(ConfigurationProvider.CONFIG_PROVIDERS_PROPERTY);
+		String providersStrList = System.getProperty(ConfigurationProvider.CONFIG_PROVIDERS_PROPERTY);
 		if (providersStrList != null) {
 			String[] providersClassNames = providersStrList.split(",");
 			for (String providerClassName : providersClassNames) {

--- a/src/main/java/de/jollyday/configuration/impl/URLConfigurationProvider.java
+++ b/src/main/java/de/jollyday/configuration/impl/URLConfigurationProvider.java
@@ -42,8 +42,7 @@ public class URLConfigurationProvider implements ConfigurationProvider {
 	@Override
 	public Properties getProperties() {
 		Properties properties = new Properties();
-		Properties systemProps = System.getProperties();
-		String configURLs = systemProps.getProperty(CONFIG_URLS_PROPERTY);
+		String configURLs = System.getProperty(CONFIG_URLS_PROPERTY);
 		if (configURLs != null) {
 			String[] strConfigURLs = configURLs.split(",");
 			for (String strURL : strConfigURLs) {


### PR DESCRIPTION
Use System.getProperty to get a specific property instead of first
retrieving all properties with System.getProperties() only to read one
property out of it.

This is more friendly to security managers: instead of requiring the
permission to read and even write all properties
("java.util.PropertyPermission" "*" "read,write"), the policy only needs
to allow reading a specific property, which is much more secure.

Depending on the JVM implementation, System.getProperty can also be more
efficient.