### PR TITLE
Added REFORMATION_DAY for Schleswig-Holstein.

### DIFF
--- a/src/main/resources/holidays/Holidays_de.xml
+++ b/src/main/resources/holidays/Holidays_de.xml
@@ -110,4 +110,9 @@
   		<tns:Fixed month="OCTOBER" day="31" descriptionPropertiesKey="REFORMATION_DAY"/>
   	</tns:Holidays>
   </tns:SubConfigurations>
+    <tns:SubConfigurations hierarchy="sh" description="Schleswig-Holstein">
+  	<tns:Holidays>
+  		<tns:Fixed month="OCTOBER" day="31" descriptionPropertiesKey="REFORMATION_DAY"/>
+  	</tns:Holidays>
+  </tns:SubConfigurations>
 </tns:Configuration>

--- a/src/test/resources/holidays/Holidays_test_de_2010.xml
+++ b/src/test/resources/holidays/Holidays_test_de_2010.xml
@@ -102,4 +102,9 @@
   		<tns:Fixed month="OCTOBER" day="31"/>
   	</tns:Holidays>
   </tns:SubConfigurations>
+  <tns:SubConfigurations hierarchy="sh" description="Schleswig-Holstein">
+  	<tns:Holidays>
+  		<tns:Fixed month="OCTOBER" day="31"/>
+  	</tns:Holidays>
+  </tns:SubConfigurations>
 </tns:Configuration>


### PR DESCRIPTION
On 22nd of Feb 2018 the Landtag in Schleswig-Hostein has decided to add
the reformation day as an offical holiday in Schleswig-Holstein:
http://www.landtag.ltsh.de/plenumonline/archiv/wp19/09/debatten/07_12.html