### PR TITLE
Avoid locking and use ConcurrentHashMap.computeIfAbsent(...) combination

### DIFF
--- a/src/main/java/de/jollyday/HolidayManager.java
+++ b/src/main/java/de/jollyday/HolidayManager.java
@@ -40,8 +40,7 @@ import java.util.logging.Logger;
  */
 public abstract class HolidayManager {
 
-	private static final Logger LOG = Logger.getLogger(HolidayManager.class
-			.getName());
+	private static final Logger LOG = Logger.getLogger(HolidayManager.class.getName());
 	/**
 	 * Signifies if caching of manager instances is enabled. If not every call
 	 * to getInstance will return a newly instantiated and initialized manager.
@@ -212,9 +211,7 @@ public abstract class HolidayManager {
 	 * Clears the manager cache from all cached manager instances.
 	 */
 	public static void clearManagerCache() {
-		synchronized (HOLIDAY_MANAGER_CACHE) {
-			HOLIDAY_MANAGER_CACHE.clear();
-		}
+		HOLIDAY_MANAGER_CACHE.clear();
 	}
 
 	/**

--- a/src/main/java/de/jollyday/caching/HolidayManagerValueHandler.java
+++ b/src/main/java/de/jollyday/caching/HolidayManagerValueHandler.java
@@ -52,18 +52,14 @@ public class HolidayManagerValueHandler implements Cache.ValueHandler<HolidayMan
 	 *            the managers class name
 	 * @return the implementation class instantiated
 	 */
-	private HolidayManager instantiateManagerImpl(
-			String managerImplClassName) {
+	private HolidayManager instantiateManagerImpl(String managerImplClassName) {
 		try {
-			Class<?> managerImplClass = classLoadingUtil
-					.loadClass(managerImplClassName);
-			Object managerImplObject = managerImplClass.newInstance();
+			Class<?> managerImplClass = classLoadingUtil.loadClass(managerImplClassName);
+			Object managerImplObject = managerImplClass.getDeclaredConstructor().newInstance();
 			return HolidayManager.class.cast(managerImplObject);
 		} catch (Exception e) {
-			throw new IllegalStateException("Cannot create manager class "
-					+ managerImplClassName, e);
+			throw new IllegalStateException("Cannot create manager class " + managerImplClassName, e);
 		}
 	}
-
 
 }

--- a/src/test/java/de/jollyday/tests/HolidayDescriptionTest.java
+++ b/src/test/java/de/jollyday/tests/HolidayDescriptionTest.java
@@ -38,13 +38,8 @@ public class HolidayDescriptionTest {
 
 		File folder = new File("src/main/resources/descriptions");
 		Assert.assertTrue(folder.isDirectory());
-		File[] descriptions = folder.listFiles(new FilenameFilter() {
-
-			@Override
-			public boolean accept(File dir, String name) {
-				return name.startsWith("holiday_descriptions") && name.endsWith(".properties");
-			}
-		});
+		File[] descriptions = folder.listFiles(
+			(dir, name) -> name.startsWith("holiday_descriptions") && name.endsWith(".properties"));
 		Assert.assertNotNull(descriptions);
 		Assert.assertTrue(descriptions.length > 0);
 

--- a/src/test/java/de/jollyday/tests/HolidayTest.java
+++ b/src/test/java/de/jollyday/tests/HolidayTest.java
@@ -157,18 +157,14 @@ public class HolidayTest {
 		ExecutorService executorService = Executors.newCachedThreadPool();
 		while (date.getYear() < 2013) {
 			final LocalDate localDate = date;
-			executorService.submit(new Runnable() {
-				@Override
-				public void run() {
-					long start = System.currentTimeMillis();
-					HolidayManager m = HolidayManager.getInstance("test");
-					m.isHoliday(localDate);
-					long duration = System.currentTimeMillis() - start;
-					duration = System.currentTimeMillis() - start;
-					count.incrementAndGet();
-					sumDuration.addAndGet(duration);
-				}
-			});
+			executorService.submit(() -> {
+        long start = System.currentTimeMillis();
+        HolidayManager m = HolidayManager.getInstance("test");
+        m.isHoliday(localDate);
+        long duration = System.currentTimeMillis() - start;
+        count.incrementAndGet();
+        sumDuration.addAndGet(duration);
+      });
 			date = date.plusDays(1);
 		}
 		executorService.shutdown();

--- a/src/test/java/de/jollyday/tests/XMLValidationTest.java
+++ b/src/test/java/de/jollyday/tests/XMLValidationTest.java
@@ -38,7 +38,7 @@ public class XMLValidationTest {
     @Test
     public void testHolidayFilesAreValid()throws Exception {
         final Path holidaysFolder = Paths.get("src/main/resources/holidays/");
-        Files.list(holidaysFolder).forEach(path -> validateHolidayFile(path));
+        Files.list(holidaysFolder).forEach(this::validateHolidayFile);
     }
 
     private void validateHolidayFile(Path path){


### PR DESCRIPTION
Avoid locking and use `ConcurrentHashMap.computeIfAbsent(...)` combination in the Cache.