### PR TITLE
Fix for issue #73

### DIFF
--- a/src/main/resources/holidays/Holidays_no.xml
+++ b/src/main/resources/holidays/Holidays_no.xml
@@ -8,12 +8,12 @@
 		<tns:Fixed month="MAY" day="17" descriptionPropertiesKey="CONSTITUTION_DAY"/>
 		<tns:Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
 		<tns:Fixed month="DECEMBER" day="26" descriptionPropertiesKey="STEPHENS"/>
-		<tns:Fixed month="DECEMBER" day="31" descriptionPropertiesKey="NEW_YEARS_EVE"/>
 		<tns:ChristianHoliday type="EASTER" />
 		<tns:ChristianHoliday type="MAUNDY_THURSDAY" />
 		<tns:ChristianHoliday type="GOOD_FRIDAY" />
 		<tns:ChristianHoliday type="EASTER_MONDAY" />
 		<tns:ChristianHoliday type="ASCENSION_DAY" />
 		<tns:ChristianHoliday type="WHIT_MONDAY" />
+		<tns:ChristianHoliday type="PENTECOST" />
 	</tns:Holidays>
 </tns:Configuration>


### PR DESCRIPTION
Fix for issue #73
Removed 31. Desember from the Norwegian Calendar 
Added Pentecost (e.g. 20. mai) to the Norwegian Calendar 