### PR TITLE
Add Europe Day

### DIFF
--- a/src/main/resources/descriptions/holiday_descriptions.properties
+++ b/src/main/resources/descriptions/holiday_descriptions.properties
@@ -58,6 +58,7 @@ holiday.description.ELECTION_DAY                   = Election day
 holiday.description.EMPERORS_BIRTHDAY              = Emperors Birthday
 holiday.description.EMPIRE                         = Empire Day
 holiday.description.EPIPHANY                       = Epiphany
+holiday.description.EUROPE_DAY                     = Europe Day
 holiday.description.EVACUATION                     = Evacuation Day
 holiday.description.FAMILY_COMMUNITY               = Family & Community day
 holiday.description.FAMILY_DAY                     = Family day

--- a/src/main/resources/descriptions/holiday_descriptions_de.properties
+++ b/src/main/resources/descriptions/holiday_descriptions_de.properties
@@ -58,6 +58,7 @@ holiday.description.ELECTION_DAY                   = Wahltag
 holiday.description.EMPERORS_BIRTHDAY              = Geburtstag des Kaisers
 holiday.description.EMPIRE                         = Empire Tag
 holiday.description.EPIPHANY                       = Heilige Drei K\u00F6nige
+holiday.description.EUROPE_DAY                     = Europatag
 holiday.description.EVACUATION                     = Evakuierungstag
 holiday.description.FAMILY_COMMUNITY               = Familien- & Gemeinschaftstag
 holiday.description.FAMILY_DAY                     = Familientag

--- a/src/main/resources/descriptions/holiday_descriptions_en.properties
+++ b/src/main/resources/descriptions/holiday_descriptions_en.properties
@@ -58,6 +58,7 @@ holiday.description.ELECTION_DAY                   = Election day
 holiday.description.EMPERORS_BIRTHDAY              = Emperors Birthday
 holiday.description.EMPIRE                         = Empire Day
 holiday.description.EPIPHANY                       = Epiphany
+holiday.description.EUROPE_DAY                     = Europe Day
 holiday.description.EVACUATION                     = Evacuation Day
 holiday.description.FAMILY_COMMUNITY               = Family & Community day
 holiday.description.FAMILY_DAY                     = Family day

--- a/src/main/resources/descriptions/holiday_descriptions_fr.properties
+++ b/src/main/resources/descriptions/holiday_descriptions_fr.properties
@@ -59,6 +59,7 @@ holiday.description.ELECTION_DAY                   = Jour des Elections
 holiday.description.EMPERORS_BIRTHDAY              = Anniversaire des Empereurs
 holiday.description.EMPIRE                         = Journ\u00E9e de l'Empire
 holiday.description.EPIPHANY                       = Epiphanie
+holiday.description.EUROPE_DAY                     = Journ\u00E9e de l'Europe
 holiday.description.EVACUATION                     = Journ\u00E9e de l'Evacuation
 holiday.description.FAMILY_COMMUNITY               = Journ\u00E9e de la Famille & de la Communaut\u00E9
 holiday.description.FAMILY_DAY                     = Journ\u00E9e de la Famille

--- a/src/main/resources/descriptions/holiday_descriptions_nl.properties
+++ b/src/main/resources/descriptions/holiday_descriptions_nl.properties
@@ -58,6 +58,7 @@ holiday.description.ELECTION_DAY                   = Dag van de verkiezingen
 holiday.description.EMPERORS_BIRTHDAY              = Verjaardag van de keizer
 holiday.description.EMPIRE                         = Empire Dag
 holiday.description.EPIPHANY                       = Driekoningen
+holiday.description.EUROPE_DAY                     = Europe Day
 holiday.description.EVACUATION                     = Dag van de evacuatie
 holiday.description.FAMILY_COMMUNITY               = Familie & community dag
 holiday.description.FAMILY_DAY                     = Familiedag

--- a/src/main/resources/descriptions/holiday_descriptions_pt.properties
+++ b/src/main/resources/descriptions/holiday_descriptions_pt.properties
@@ -59,6 +59,7 @@ holiday.description.ELECTION_DAY                   = Dia de Elei\u00E7\u00F5es
 holiday.description.EMPERORS_BIRTHDAY              = Anivers\u00E1rio dos Imperadores
 holiday.description.EMPIRE                         = Dia do Imp\u00E9rio
 holiday.description.EPIPHANY                       = Epif\u00E2nia
+holiday.description.EUROPE_DAY                     = Dia da Europa
 holiday.description.EVACUATION                     = Evacuation Day
 holiday.description.FAMILY_COMMUNITY               = Dia da Fam\u00EDlia e da Comunidade
 holiday.description.FAMILY_DAY                     = Dia da Fam\u00EDlia

--- a/src/main/resources/descriptions/holiday_descriptions_sv.properties
+++ b/src/main/resources/descriptions/holiday_descriptions_sv.properties
@@ -59,6 +59,7 @@ holiday.description.ELECTION_DAY                   = Election day
 holiday.description.EMPERORS_BIRTHDAY              = Emperors Birthday
 holiday.description.EMPIRE                         = Empire Day
 holiday.description.EPIPHANY                       = Epiphany
+holiday.description.EUROPE_DAY                     = Europe Day
 holiday.description.EVACUATION                     = Evacuation Day
 holiday.description.FAMILY_COMMUNITY               = Family & Community day
 holiday.description.FAMILY_DAY                     = Family day


### PR DESCRIPTION
As it was missing in the holiday descriptions I add the "EUROPE_DAY" entry to all files, adding the translations I could. Unfortunately I am unsure what it is (or would be) called in the Netherlands and Sweden.
