### PR TITLE
Added "Weltkindertag" in Thuringa Germany

### DIFF
--- a/src/main/resources/holidays/Holidays_de.xml
+++ b/src/main/resources/holidays/Holidays_de.xml
@@ -116,6 +116,7 @@
     </tns:SubConfigurations>
     <tns:SubConfigurations hierarchy="th" description="Thuringia">
         <tns:Holidays>
+            <tns:Fixed month="SEPTEMBER" day="20" descriptionPropertiesKey="CHILDRENS_DAY" validFrom="2019"/>
             <tns:Fixed month="OCTOBER" day="31" descriptionPropertiesKey="REFORMATION_DAY"/>
         </tns:Holidays>
     </tns:SubConfigurations>


### PR DESCRIPTION
source: https://www.thueringer-landtag.de/service/presse/pressemitteilungen/weltkindertag-am-20-september-wird-gesetzlicher-feiertag/

Based on ThürFGtG §2:
http://landesrecht.thueringen.de/jportal/?quelle=jlink&query=FeiertG+TH&psml=bsthueprod.psml&max=true&aiz=true