### PR TITLE
Calendar adjustment implemented for Colombia for fixed dates

### DIFF
--- a/src/main/resources/holidays/Holidays_co.xml
+++ b/src/main/resources/holidays/Holidays_co.xml
@@ -47,15 +47,50 @@
 			<tns:MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY" />
 			<tns:MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY" />
 		</tns:Fixed>
-		<tns:Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="ALL_SAINTS"/>
-		<tns:Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="CARTAGENA"/>
+		<tns:Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="ALL_SAINTS">
+			<tns:MovingCondition substitute="TUESDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="WEDNESDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="THURSDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="FRIDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY" />
+		</tns:Fixed>
+		<tns:Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="CARTAGENA">
+			<tns:MovingCondition substitute="TUESDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="WEDNESDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="THURSDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="FRIDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY" />
+		</tns:Fixed>
 		<tns:Fixed month="DECEMBER" day="8" descriptionPropertiesKey="IMMACULATE_CONCEPTION"/>
 		<tns:Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
 		<tns:ChristianHoliday type="EASTER" />
 		<tns:ChristianHoliday type="MAUNDY_THURSDAY" />
 		<tns:ChristianHoliday type="GOOD_FRIDAY" />
-		<tns:ChristianHoliday type="ASCENSION_DAY" />
-		<tns:ChristianHoliday type="CORPUS_CHRISTI" />
-		<tns:ChristianHoliday type="SACRED_HEART" />
+		<tns:ChristianHoliday type="ASCENSION_DAY" >
+			<tns:MovingCondition substitute="TUESDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="WEDNESDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="THURSDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="FRIDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY" />
+		</tns:ChristianHoliday>
+		<tns:ChristianHoliday type="CORPUS_CHRISTI" >
+			<tns:MovingCondition substitute="TUESDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="WEDNESDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="THURSDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="FRIDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY" />
+		</tns:ChristianHoliday>
+		<tns:ChristianHoliday type="SACRED_HEART" >
+			<tns:MovingCondition substitute="TUESDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="WEDNESDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="THURSDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="FRIDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY" />
+			<tns:MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY" />
+		</tns:ChristianHoliday>
 	</tns:Holidays>
 </tns:Configuration>


### PR DESCRIPTION
Calendar adjustment implemented for Colombia for following fixed dates: All saints, Cartagena, Ascension day, Corpus Christi and Sacred heart. Those days needed to be moved to the next monday when day doesn't fall on monday in the year consulted.