### PR TITLE
Fix build process for JDK 11-16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,8 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>--add-opens de.jollyday/de.jollyday.config=java.xml.bind
+                            <argLine>@{argLine}
+							         --add-opens de.jollyday/de.jollyday.config=java.xml.bind
                                      --add-opens de.jollyday/de.jollyday.configuration=ALL-UNNAMED
                                      --add-opens de.jollyday/de.jollyday.datasource.impl=ALL-UNNAMED
                                      --add-opens de.jollyday/de.jollyday.util=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.0.0-M5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -148,7 +148,7 @@
                 <plugin>
                     <groupId>biz.aQute.bnd</groupId>
                     <artifactId>bnd-maven-plugin</artifactId>
-                    <version>4.1.0</version>
+                    <version>5.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -160,14 +160,19 @@
                     <version>3.0.0-M2</version>
                 </plugin>
                 <plugin>
-               		<groupId>org.jacoco</groupId>
-               		<artifactId>jacoco-maven-plugin</artifactId>
-               		<version>0.8.3</version>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.3</version>
                     <configuration>
                         <excludes>
                             <exclude>de.jollyday.config.*</exclude>
                         </excludes>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.eclipse.transformer</groupId>
+                    <artifactId>org.eclipse.transformer.maven</artifactId>
+                    <version>0.2.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -185,6 +190,7 @@
                         <configuration>
                             <systemProperties>
                                 <enableExternalEntityProcessing>true</enableExternalEntityProcessing>
+                                <user.language>en_US</user.language>
                             </systemProperties>
                             <jvmArguments>
                                 <jvmArgument>-Xms32m</jvmArgument>
@@ -263,9 +269,9 @@
                 </configuration>
                 <dependencies>
                     <dependency>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                        <version>2.4.0-b180830.0359</version>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>2.3.3</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -283,6 +289,22 @@
                                     <version>3.0.5</version>
                                 </requireMavenVersion>
                             </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.transformer</groupId>
+                <artifactId>org.eclipse.transformer.maven</artifactId>
+                <executions>
+                    <execution>
+                        <id>jakarta-ee</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <classifier>jakarta</classifier>
                         </configuration>
                     </execution>
                 </executions>
@@ -312,6 +334,30 @@
             </build>
         </profile>
         <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-opens de.jollyday/de.jollyday.config=java.xml.bind
+                                     --add-opens de.jollyday/de.jollyday.configuration=ALL-UNNAMED
+                                     --add-opens de.jollyday/de.jollyday.datasource.impl=ALL-UNNAMED
+                                     --add-opens de.jollyday/de.jollyday.util=ALL-UNNAMED
+                                     --add-opens de.jollyday/holidays=ALL-UNNAMED</argLine>
+                            <additionalClasspathElements>
+                                <additionalClasspathElement>${project.basedir}/src/main/resources</additionalClasspathElement>
+                            </additionalClasspathElements>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>jdk11</id>
             <activation>
                 <jdk>[11,)</jdk>
@@ -331,14 +377,14 @@
             </build>
             <dependencies>
                 <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                    <version>2.4.0-b180830.0359</version>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                    <version>2.3.3</version>
                 </dependency>
                 <dependency>
                     <groupId>org.glassfish.jaxb</groupId>
                     <artifactId>jaxb-runtime</artifactId>
-                    <version>2.4.0-b180830.0438</version>
+                    <version>2.3.4</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <project.scm.id>sourceforge.net</project.scm.id>
         <maven.site.skip>true</maven.site.skip>
         <maven.site.deploy.skip>true</maven.site.deploy.skip>
+        <argLine /> <!-- this hack is required because of the JDK 9 build profile - JaCoCo vs. Surefire: @{argLine} -->
     </properties>
     <developers>
         <developer>
@@ -162,7 +163,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.3</version>
+                    <version>0.8.7</version>
                     <configuration>
                         <excludes>
                             <exclude>de.jollyday.config.*</exclude>


### PR DESCRIPTION
Tested build process with JDK 8, 11, 13-16

This project is used in a JavaEE 7 application which should be upgraded to the new JakartaEE 9.1 on JDK 16. During this process I recognized that there are multiple errors while running maven for this project:

- The generated JAXB classes should always use English for class comments. My machine used German and produced some errors because of umlauts.
- `bnd-maven-plugin` had to be updated because of a ConcurrentModificationException
- `xmlutils-core 2.8.2` depents on the newer `jakarta.xml.bind-api` while the JDK 11 build profile still used the older `javax.xml.bind` dependency. This produced some more errors - like not found modules (`jakarta.activation`) or same packages/classes from multiple JARs.
- Adjusted the JDK 9 build profile to included required `--add-opens` - and as a workaround (because of missing resources during test) the resources of `src/main` as additional classpath element.
- Added the transformer plugin from Eclipse to automatically produce a Jakarta-namespace compatible jar file (classifier `jakarta`)