### PR TITLE
Added missing days for Madrid and removed Easter day

### DIFF
--- a/src/main/resources/holidays/Holidays_es.xml
+++ b/src/main/resources/holidays/Holidays_es.xml
@@ -9,7 +9,6 @@
 	  <tns:Fixed month="DECEMBER" day="6" validFrom="1978" descriptionPropertiesKey="CONSTITUTION_DAY"/>
 	  <tns:Fixed month="DECEMBER" day="8" descriptionPropertiesKey="IMMACULATE_CONCEPTION"/>
 	  <tns:Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-	  <tns:ChristianHoliday type="EASTER" />
 	  <tns:ChristianHoliday type="GOOD_FRIDAY"/>
   </tns:Holidays>
   <tns:SubConfigurations hierarchy="an" description="Andalucia">
@@ -122,10 +121,16 @@
  <tns:SubConfigurations hierarchy="m" description="Madrid">
   	<tns:Holidays>
   		<tns:Fixed month="MARCH" day="19" descriptionPropertiesKey="ST_JOSEPH"/>
+  		<tns:Fixed month="MAY" day="2" descriptionPropertiesKey="REGIONAL"/>
 		<tns:Fixed month="AUGUST" day="15" descriptionPropertiesKey="ASSUMPTION_DAY"/>
-  		<tns:ChristianHoliday type="CORPUS_CHRISTI" />
   		<tns:ChristianHoliday type="MAUNDY_THURSDAY"/>
   	</tns:Holidays>
+  	<tns:SubConfigurations hierarchy="mad" description="Madrid city">
+		<tns:Holidays>
+      <tns:Fixed month="MAY" day="15" descriptionPropertiesKey="SAINT_ISIDORE"/>
+      <tns:Fixed month="NOVEMBER" day="9" descriptionPropertiesKey="ALMUDENA_DAY"/>
+		</tns:Holidays>
+	</tns:SubConfigurations>
  </tns:SubConfigurations>
  <tns:SubConfigurations hierarchy="mu" description="Murcia">
   	<tns:Holidays>
@@ -178,3 +183,6 @@
   	</tns:Holidays>
  </tns:SubConfigurations>
 </tns:Configuration>
+
+
+


### PR DESCRIPTION
I have added some holidays for the city of Madrid and named with subconfiguration mad. Also, I have corrected another for the region of Madrid and removed Easter day for the whole country as it is just Sunday, not holiday. I have to set them fixed as some years they are moved to Mondays but not always. Having the dates updated for our country is now more important as the new electric tariff considers national fixed holidays as off-peak time, thus being cheaper.