### PR TITLE
Australia/New Zealand updates

### DIFF
--- a/src/main/resources/descriptions/holiday_descriptions.properties
+++ b/src/main/resources/descriptions/holiday_descriptions.properties
@@ -182,6 +182,7 @@ holiday.description.PRESIDENTS_DAY                 = Presidents Day
 holiday.description.PROCLAMATION                   = Proclamation Day
 holiday.description.PULASKI                        = Casimir Pulaski Day
 holiday.description.QUEENS_BIRTHDAY                = Queen's birthday
+holiday.description.QEII_MEMORIAL_DAY              = Queen Elizabeth II Memorial Day
 holiday.description.RACE                           = Day of the Race
 holiday.description.RECONCILIATION                 = Day of Reconciliation
 holiday.description.RECREATION                     = Recreation Day

--- a/src/main/resources/descriptions/holiday_descriptions.properties
+++ b/src/main/resources/descriptions/holiday_descriptions.properties
@@ -160,6 +160,7 @@ holiday.description.MOTHERS_DAY                    = Mothers Day
 holiday.description.MOTHER_TERESA                  = Beatification of Mother Teresa
 holiday.description.MOUNTAIN_DAY                   = Mountain day
 holiday.description.NATIONAL_DAY                   = National Day
+holiday.description.NATIONAL_MOURNING              = National Day of Mourning
 holiday.description.NATIONAL_UPRISING              = National Uprising
 holiday.description.NATIVITY_LADY                  = Nativity of our Lady
 holiday.description.NATIVITY_MARY                  = Nativity of Mary

--- a/src/main/resources/descriptions/holiday_descriptions.properties
+++ b/src/main/resources/descriptions/holiday_descriptions.properties
@@ -18,6 +18,7 @@ holiday.description.ARTIGAS                        = Artigas' Birthday
 holiday.description.ASSUMPTION_DAY                 = Assumption day
 holiday.description.ASSUMPTION_MARY                = Assumption of Mary
 holiday.description.AUCKLAND_ANNIVERSARY           = Auckland Anniversary
+holiday.description.AUSTRALIA_DAY                  = Australia day
 holiday.description.BANK_HOLIDAY                   = Bank Holiday
 holiday.description.BATTLE_BOYNE                   = Battle of the Boyne
 holiday.description.BATTLE_JACINTO                 = Battle of San Jacinto

--- a/src/main/resources/holidays/Holidays_au.xml
+++ b/src/main/resources/holidays/Holidays_au.xml
@@ -36,6 +36,7 @@
 			<tns:MovingCondition substitute="SUNDAY" with="NEXT" weekday="TUESDAY"/>
 			<tns:MovingCondition substitute="MONDAY" with="NEXT" weekday="TUESDAY"/>
 		</tns:Fixed>
+		<tns:Fixed month="SEPTEMBER" day="22" validFrom="2022" validTo="2022" descriptionPropertiesKey="NATIONAL_MOURNING"/>
 		<tns:ChristianHoliday type="EASTER" />
 		<tns:ChristianHoliday type="GOOD_FRIDAY"/>
 		<tns:ChristianHoliday type="EASTER_SATURDAY"/>

--- a/src/main/resources/holidays/Holidays_au.xml
+++ b/src/main/resources/holidays/Holidays_au.xml
@@ -12,8 +12,8 @@
 			<tns:MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
 			<tns:MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
 		</tns:Fixed>
-		<tns:Fixed month="JANUARY" day="26" validTo="2007" descriptionPropertiesKey="NATIONAL_DAY"/>
-		<tns:Fixed month="JANUARY" day="26" validFrom="2008" descriptionPropertiesKey="NATIONAL_DAY">
+		<tns:Fixed month="JANUARY" day="26" validTo="2007" descriptionPropertiesKey="AUSTRALIA_DAY"/>
+		<tns:Fixed month="JANUARY" day="26" validFrom="2008" descriptionPropertiesKey="AUSTRALIA_DAY">
 			<tns:MovingCondition substitute="SATURDAY" with="NEXT" weekday="MONDAY"/>
 			<tns:MovingCondition substitute="SUNDAY" with="NEXT" weekday="MONDAY"/>
 		</tns:Fixed>

--- a/src/main/resources/holidays/Holidays_nz.xml
+++ b/src/main/resources/holidays/Holidays_nz.xml
@@ -63,6 +63,8 @@
     <tns:Fixed month="JUNE" day="30" validFrom="2051" validTo="2051" descriptionPropertiesKey="MATARIKI"/>
     <tns:Fixed month="JUNE" day="21" validFrom="2052" validTo="2052" descriptionPropertiesKey="MATARIKI"/>
 
+    <tns:Fixed month="SEPTEMBER" day="26" validFrom="2022" validTo="2022" descriptionPropertiesKey="QEII_MEMORIAL_DAY"/>
+
 		<tns:FixedWeekday which="FIRST" weekday="MONDAY" month="JUNE" descriptionPropertiesKey="QUEENS_BIRTHDAY"/>
 		<tns:FixedWeekday which="FOURTH" weekday="MONDAY" month="OCTOBER" descriptionPropertiesKey="LABOUR_DAY"/>
 


### PR DESCRIPTION
Added one-off holidays for Australia and New Zealand after Queen died
Fixed name of "Australia Day"