### PR TITLE
International Womens Day in Germany

### DIFF
--- a/src/main/resources/holidays/Holidays_de.xml
+++ b/src/main/resources/holidays/Holidays_de.xml
@@ -77,6 +77,7 @@
     </tns:SubConfigurations>
     <tns:SubConfigurations hierarchy="mv" description="Mecklenburg-Vorpommern">
         <tns:Holidays>
+            <tns:Fixed month="MARCH" day="8" descriptionPropertiesKey="INTERNATIONAL_WOMAN" validFrom="2023"/>
             <tns:Fixed month="OCTOBER" day="31" descriptionPropertiesKey="REFORMATION_DAY"/>
         </tns:Holidays>
     </tns:SubConfigurations>


### PR DESCRIPTION
Adding International Womens Day to Mecklenburg-Vorpommern (Germany)

Draft of the law: https://www.landtag-mv.de/fileadmin/media/Dokumente/Parlamentsdokumente/Drucksachen/8_Wahlperiode/D08-0000/Drs08-0793.pdf
The law itself: https://www.landesrecht-mv.de/bsmv/document/jlr-FTGMVV3P2

I would really like to see this included and a new release.