### PR TITLE
Update Holidays_fr.xml - removed EASTER

### DIFF
--- a/src/main/resources/holidays/Holidays_fr.xml
+++ b/src/main/resources/holidays/Holidays_fr.xml
@@ -11,7 +11,6 @@
 		<tns:Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="ALL_SAINTS"/>
 		<tns:Fixed month="NOVEMBER" day="11" descriptionPropertiesKey="REMEMBRANCE"/>
 		<tns:Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
-		<tns:ChristianHoliday type="EASTER" />
 		<tns:ChristianHoliday type="EASTER_MONDAY" />
 		<tns:ChristianHoliday type="ASCENSION_DAY" />
 		<tns:ChristianHoliday type="WHIT_MONDAY" validTo="2003" />


### PR DESCRIPTION
According to the French Labour code, the easter sunday is not a holiday.
Here is a government notice on public holidays in France : https://code.travail.gouv.fr/fiche-ministere-travail/les-jours-feries-et-les-ponts