### PR TITLE
Update Holidays_de.xml Add int. womanday to DE MV

### DIFF
--- a/src/main/resources/holidays/Holidays_de.xml
+++ b/src/main/resources/holidays/Holidays_de.xml
@@ -77,6 +77,7 @@
     </tns:SubConfigurations>
     <tns:SubConfigurations hierarchy="mv" description="Mecklenburg-Vorpommern">
         <tns:Holidays>
+            <tns:Fixed month="MARCH" day="8" descriptionPropertiesKey="INTERNATIONAL_WOMAN" validFrom="2023"/>
             <tns:Fixed month="OCTOBER" day="31" descriptionPropertiesKey="REFORMATION_DAY"/>
         </tns:Holidays>
     </tns:SubConfigurations>


### PR DESCRIPTION
International Women's Day became a regional holyday in Mecklenburg-Vorpommern in 2023 (see https://www.ndr.de/nachrichten/mecklenburg-vorpommern/Frauentag-in-MV-Landtag-beschliesst-neuen-Feiertag,frauentag370.html )