### PR TITLE
Update Holidays_de.xml

### DIFF
--- a/src/main/resources/holidays/Holidays_de.xml
+++ b/src/main/resources/holidays/Holidays_de.xml
@@ -72,6 +72,7 @@
     </tns:SubConfigurations>
     <tns:SubConfigurations hierarchy="he" description="Hesse">
         <tns:Holidays>
+            <tns:ChristianHoliday type="EASTER"/>
             <tns:ChristianHoliday type="CORPUS_CHRISTI"/>
         </tns:Holidays>
     </tns:SubConfigurations>


### PR DESCRIPTION
In Hessen, Easter is also Bank Holiday.